### PR TITLE
refactor: severityError option reduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ module.exports = {
 |       **`include`**        | `{String\/RegExp\|Array<String\|RegExp>}` |                         `undefined`                         | Files to `include`                                                                                |
 |       **`exclude`**        | `{String\/RegExp\|Array<String\|RegExp>}` |                         `undefined`                         | Files to `exclude`                                                                                |
 |        **`filter`**        |               `{Function}`                |                        `() => true`                         | Allows filtering of images for optimization                                                       |
-|    **`severityError`**     |            `{Boolean\|String}`            |                          `'auto'`                           | Allows to choose how errors are displayed                                                         |
+|    **`severityError`**     |                `{String}`                 |                          `'error'`                          | Allows to choose how errors are displayed                                                         |
 |        **`minify`**        |      `{Function \| Array<Function>}`      |            `ImageMinimizerPlugin.imageminMinify`            | Allows to override default minify function                                                        |
 |   **`minimizerOptions`**   |         `{Object\|Array<Object>}`         |                      `{ plugins: [] }`                      | Options for `imagemin`                                                                            |
 |        **`loader`**        |                `{Boolean}`                |                           `true`                            | Automatically adding `imagemin-loader`                                                            |
@@ -300,17 +300,16 @@ module.exports = {
 
 #### `severityError`
 
-Type: `Boolean|String`
-Default: `'auto'`
+Type: `String`
+Default: `'error'`
 
 Allows to choose how errors are displayed.
 
 Сan have the following values:
 
-- `'auto'` - emit warnings in `development` mode and emit errors in `production` mode (default behavior)
-- `false` or `'off'` - suppresses errors and warnings
+- `'off'` - suppresses errors and warnings
 - `'warning'` - emit warnings instead errors
-- `true` or `'error'` - emit errors
+- `'error'` - emit errors
 
 **webpack.config.js**
 
@@ -630,7 +629,7 @@ module.exports = {
 |            Name            |              Type               |                Default                | Description                                                                                       |
 | :------------------------: | :-----------------------------: | :-----------------------------------: | :------------------------------------------------------------------------------------------------ |
 |        **`filter`**        |          `{Function}`           |              `undefined`              | Allows filtering of images for optimization                                                       |
-|    **`severityError`**     |       `{Boolean\|String}`       |               `'auto'`                | Allows to choose how errors are displayed                                                         |
+|    **`severityError`**     |           `{String}`            |               `'error'`               | Allows to choose how errors are displayed                                                         |
 |        **`minify`**        | `{Function \| Array<Function>}` | `ImageMinimizerPlugin.imageminMinify` | Allows to override default minify function                                                        |
 |   **`minimizerOptions`**   |    `{Object\|Array<Object>}`    |           `{ plugins: [] }`           | Options for `imagemin`                                                                            |
 |       **`filename`**       |           `{string}`            |         `'[path][name][ext]'`         | Allows to set the filename for the generated asset. Useful for converting to a `webp`             |
@@ -687,17 +686,16 @@ module.exports = {
 
 #### `severityError`
 
-Type: `Boolean|String`
-Default: `'auto'`
+Type: `String`
+Default: `'error'`
 
 Allows to choose how errors are displayed.
 
 Сan have the following values:
 
-- `'auto'` - emit warnings in `development` mode and emit errors in `production` mode (default behavior)
-- `false` or `'off'` - suppresses errors and warnings
+- `'off'` - suppresses errors and warnings
 - `'warning'` - emit warnings instead errors
-- `true` or `'error'` - emit errors
+- `'error'` - emit errors
 
 **webpack.config.js**
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ import imageminMinify from "./utils/imageminMinify";
  * @property {string|RegExp|Array<string|RegExp>} [test=/\.(jpe?g|png|gif|tif|webp|svg|avif)$/i] Test to match files against.
  * @property {string|RegExp|Array<string|RegExp>} [include] Files to include.
  * @property {string|RegExp|Array<string|RegExp>} [exclude] Files to exclude.
- * @property {boolean|string} [severityError='auto'] Allows to choose how errors are displayed.
+ * @property {boolean|string} [severityError='error'] Allows to choose how errors are displayed.
  * @property {Object} [minimizerOptions={plugins: []}] Options for `imagemin`.
  * @property {boolean} [loader=true] Automatically adding `imagemin-loader`.
  * @property {number} [maxConcurrency=Math.max(1, os.cpus().length - 1)] Maximum number of concurrency optimization processes in one time.

--- a/src/loader-options.json
+++ b/src/loader-options.json
@@ -30,14 +30,7 @@
     },
     "severityError": {
       "description": "Allows to choose how errors are displayed.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "string"
-        }
-      ]
+      "type": "string"
     },
     "filename": {
       "type": "string"

--- a/src/minify.js
+++ b/src/minify.js
@@ -50,22 +50,13 @@ async function minify(options = {}) {
 
       switch (options.severityError) {
         case "off":
-        case false:
-          break;
-        case "error":
-        case true:
-          errors.push(error);
           break;
         case "warning":
           result.warnings.push(error);
           break;
-        case "auto":
+        case "error":
         default:
-          if (options.isProductionMode) {
-            errors.push(error);
-          } else {
-            result.warnings.push(error);
-          }
+          errors.push(error);
       }
     }
 

--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -84,14 +84,7 @@
     },
     "severityError": {
       "description": "Allows to choose how errors are displayed.",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "string"
-        }
-      ]
+      "type": "string"
     },
     "loader": {
       "description": "Automatically adding `imagemin-loader` (require for minification images using in `url-loader`, `svg-url-loader` or other).",

--- a/test/__snapshots__/validate-loader-options.test.js.snap
+++ b/test/__snapshots__/validate-loader-options.test.js.snap
@@ -170,32 +170,32 @@ exports[`validate loader options should throw an error on the "minimizerOptions"
 
 exports[`validate loader options should throw an error on the "severityError" option with "() => {}" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
- - options.severityError should be one of these:
-   boolean | string
-   -> Allows to choose how errors are displayed.
-   Details:
-    * options.severityError should be a boolean.
-    * options.severityError should be a string."
+ - options.severityError should be a string.
+   -> Allows to choose how errors are displayed."
 `;
 
 exports[`validate loader options should throw an error on the "severityError" option with "[]" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
- - options.severityError should be one of these:
-   boolean | string
-   -> Allows to choose how errors are displayed.
-   Details:
-    * options.severityError should be a boolean.
-    * options.severityError should be a string."
+ - options.severityError should be a string.
+   -> Allows to choose how errors are displayed."
 `;
 
 exports[`validate loader options should throw an error on the "severityError" option with "{}" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
- - options.severityError should be one of these:
-   boolean | string
-   -> Allows to choose how errors are displayed.
-   Details:
-    * options.severityError should be a boolean.
-    * options.severityError should be a string."
+ - options.severityError should be a string.
+   -> Allows to choose how errors are displayed."
+`;
+
+exports[`validate loader options should throw an error on the "severityError" option with "false" value 1`] = `
+"Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
+ - options.severityError should be a string.
+   -> Allows to choose how errors are displayed."
+`;
+
+exports[`validate loader options should throw an error on the "severityError" option with "true" value 1`] = `
+"Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
+ - options.severityError should be a string.
+   -> Allows to choose how errors are displayed."
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "/test/" value 1`] = `

--- a/test/__snapshots__/validate-plugin-options.test.js.snap
+++ b/test/__snapshots__/validate-plugin-options.test.js.snap
@@ -114,20 +114,28 @@ exports[`validate plugin options should work 10`] = `
 
 exports[`validate plugin options should work 11`] = `
 "Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
- - options.severityError should be one of these:
-   boolean | string
-   -> Allows to choose how errors are displayed.
-   Details:
-    * options.severityError should be a boolean.
-    * options.severityError should be a string."
+ - options.severityError should be a string.
+   -> Allows to choose how errors are displayed."
 `;
 
 exports[`validate plugin options should work 12`] = `
 "Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
- - options.deleteOriginalAssets should be a boolean."
+ - options.severityError should be a string.
+   -> Allows to choose how errors are displayed."
 `;
 
 exports[`validate plugin options should work 13`] = `
+"Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
+ - options.severityError should be a string.
+   -> Allows to choose how errors are displayed."
+`;
+
+exports[`validate plugin options should work 14`] = `
+"Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
+ - options.deleteOriginalAssets should be a boolean."
+`;
+
+exports[`validate plugin options should work 15`] = `
 "Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
  - options.minimizerOptions should be one of these:
    object { … } | [object { … }, ...] (should not have fewer than 1 item)
@@ -139,25 +147,25 @@ exports[`validate plugin options should work 13`] = `
       [object { … }, ...] (should not have fewer than 1 item)"
 `;
 
-exports[`validate plugin options should work 14`] = `
-"Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
- - options.maxConcurrency should be a number.
-   -> Maximum number of concurrency optimization processes in one time."
-`;
-
-exports[`validate plugin options should work 15`] = `
-"Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
- - options.maxConcurrency should be a number.
-   -> Maximum number of concurrency optimization processes in one time."
-`;
-
 exports[`validate plugin options should work 16`] = `
+"Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
+ - options.maxConcurrency should be a number.
+   -> Maximum number of concurrency optimization processes in one time."
+`;
+
+exports[`validate plugin options should work 17`] = `
+"Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
+ - options.maxConcurrency should be a number.
+   -> Maximum number of concurrency optimization processes in one time."
+`;
+
+exports[`validate plugin options should work 18`] = `
 "Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
  - options.loader should be a boolean.
    -> Automatically adding \`imagemin-loader\` (require for minification images using in \`url-loader\`, \`svg-url-loader\` or other)."
 `;
 
-exports[`validate plugin options should work 17`] = `
+exports[`validate plugin options should work 19`] = `
 "Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
  - options.minify should be one of these:
    function | [function, ...] (should not have fewer than 1 item)

--- a/test/loader-minify-option.test.js
+++ b/test/loader-minify-option.test.js
@@ -178,7 +178,7 @@ describe("loader minify option", () => {
     );
   });
 
-  it("should emit warning", async () => {
+  it("should emit errors", async () => {
     const stats = await webpack({
       imageminLoader: true,
       imageminLoaderOptions: {
@@ -190,8 +190,8 @@ describe("loader minify option", () => {
     const { compilation } = stats;
     const { warnings, errors } = compilation;
 
-    expect(warnings).toHaveLength(4);
-    expect(errors).toHaveLength(0);
+    expect(errors).toHaveLength(4);
+    expect(warnings).toHaveLength(0);
 
     await expect(isOptimized("loader-test.gif", compilation)).resolves.toBe(
       false

--- a/test/loader-severityError-option.test.js
+++ b/test/loader-severityError-option.test.js
@@ -3,29 +3,6 @@ import path from "path";
 import { fixturesPath, isOptimized, plugins, webpack } from "./helpers";
 
 describe("loader severityError option", () => {
-  it("should throws error on corrupted images using `severityError` option with `true` value", async () => {
-    const stats = await webpack({
-      entry: path.join(fixturesPath, "loader-corrupted.js"),
-      imageminLoaderOptions: {
-        severityError: true,
-        minimizerOptions: { plugins },
-      },
-    });
-    const { compilation } = stats;
-    const { assets, warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
-    expect(Object.keys(assets)).toHaveLength(3);
-
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
   it("should throws error on corrupted images using `severityError` option with `error` value", async () => {
     const stats = await webpack({
       entry: path.join(fixturesPath, "loader-corrupted.js"),
@@ -86,77 +63,6 @@ describe("loader severityError option", () => {
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
 
-    expect(Object.keys(assets)).toHaveLength(3);
-
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
-  it("should throws error on corrupted images using `severityError` option with `false` value", async () => {
-    const stats = await webpack({
-      entry: path.join(fixturesPath, "loader-corrupted.js"),
-      imageminLoaderOptions: {
-        severityError: false,
-        minimizerOptions: { plugins },
-      },
-    });
-    const { compilation } = stats;
-    const { assets, warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-
-    expect(Object.keys(assets)).toHaveLength(3);
-
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
-  it("should throws error on corrupted images using `severityError` option with `auto` value", async () => {
-    const stats = await webpack({
-      entry: path.join(fixturesPath, "loader-corrupted.js"),
-      imageminLoaderOptions: {
-        severityError: "auto",
-        minimizerOptions: { plugins },
-      },
-    });
-    const { compilation } = stats;
-    const { assets, warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(1);
-    expect(errors).toHaveLength(0);
-    expect(warnings[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
-    expect(Object.keys(assets)).toHaveLength(3);
-
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
-  it("should throws error on corrupted images using mode `production` and `severityError` option with `auto` value", async () => {
-    const stats = await webpack({
-      mode: "production",
-      optimization: {
-        emitOnErrors: true,
-      },
-      entry: path.join(fixturesPath, "loader-corrupted.js"),
-      imageminLoaderOptions: {
-        severityError: "auto",
-        minimizerOptions: { plugins },
-      },
-    });
-    const { compilation } = stats;
-    const { assets, warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
     expect(Object.keys(assets)).toHaveLength(3);
 
     await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(

--- a/test/minify.test.js
+++ b/test/minify.test.js
@@ -169,16 +169,19 @@ describe("minify", () => {
       minimizerOptions: { plugins: false },
     });
 
-    expect(result.warnings).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0].toString()).toMatch(
       /No plugins found for `imagemin`/
     );
-    expect(result.errors).toHaveLength(0);
+    expect(result.errors[0].toString()).toMatch(
+      "TypeError: Found non-callable @@iterator"
+    );
     expect(result.filename).toBe(filename);
     expect(result.data.equals(input)).toBe(true);
   });
 
-  it("should return original content and emit a warning on invalid content (`String`)", async () => {
+  it("should return original content and emit a error on invalid content (`String`)", async () => {
     const input = "Foo";
     const result = await minify({
       minify: imageminMinify,
@@ -187,8 +190,8 @@ describe("minify", () => {
       minimizerOptions: { plugins: ["mozjpeg"] },
     });
 
-    expect(result.warnings).toHaveLength(1);
-    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
     expect(result.data).toBe(input);
   });
 
@@ -449,7 +452,7 @@ describe("minify", () => {
     expect(result.data.equals(optimizedSource)).toBe(true);
   });
 
-  it("should throw two warnings", async () => {
+  it("should throw two errors", async () => {
     const filename = path.resolve(__dirname, "./fixtures/loader-test.jpg");
     const input = await pify(fs.readFile)(filename);
     const result = await minify({
@@ -461,9 +464,9 @@ describe("minify", () => {
       filename,
     });
 
-    expect(result.warnings).toHaveLength(2);
-    expect(result.warnings[0].toString()).toMatch(/Error: fail/);
-    expect(result.warnings[1].toString()).toMatch(/Error: fail/);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0].toString()).toMatch(/Error: fail/);
+    expect(result.errors[1].toString()).toMatch(/Error: fail/);
     expect(result.filename).toBe(filename);
   });
 });

--- a/test/plugin-severityError-option.test.js
+++ b/test/plugin-severityError-option.test.js
@@ -3,33 +3,6 @@ import path from "path";
 import { fixturesPath, isOptimized, plugins, webpack } from "./helpers";
 
 describe("plugin severityError option", () => {
-  it("should optimizes images and throws error on corrupted images using `plugin.severityError` option with `true` value (by plugin)", async () => {
-    const stats = await webpack({
-      emitPluginOptions: {
-        fileNames: ["test-corrupted.jpg", "plugin-test.png"],
-      },
-      entry: path.join(fixturesPath, "empty-entry.js"),
-      imageminPluginOptions: {
-        severityError: true,
-        minimizerOptions: {
-          plugins,
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
-
-    await expect(isOptimized("plugin-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
   it("should optimizes images and throws error on corrupted images using `plugin.severityError` option with `error` value (by plugin)", async () => {
     const stats = await webpack({
       emitPluginOptions: {
@@ -81,30 +54,6 @@ describe("plugin severityError option", () => {
     );
   });
 
-  it("should optimizes images and not throws error or warnings on corrupted images using `plugin.severityError` option with false value (by plugin)", async () => {
-    const stats = await webpack({
-      emitPluginOptions: {
-        fileNames: ["test-corrupted.jpg", "plugin-test.png"],
-      },
-      entry: path.join(fixturesPath, "empty-entry.js"),
-      imageminPluginOptions: {
-        severityError: false,
-        minimizerOptions: {
-          plugins,
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-
-    await expect(isOptimized("plugin-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
   it("should optimizes images and throws warnings on corrupted images using `plugin.severityError` option with `warning` value (by plugin)", async () => {
     const stats = await webpack({
       emitPluginOptions: {
@@ -113,34 +62,6 @@ describe("plugin severityError option", () => {
       entry: path.join(fixturesPath, "empty-entry.js"),
       imageminPluginOptions: {
         severityError: "warning",
-        minimizerOptions: {
-          plugins,
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(1);
-    expect(errors).toHaveLength(0);
-    expect(warnings[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
-
-    await expect(isOptimized("plugin-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
-  it("should optimizes images and throws error on corrupted images using mode `development` and `plugin.severityError` option with `auto` value (by plugin)", async () => {
-    const stats = await webpack({
-      mode: "development",
-      emitPluginOptions: {
-        fileNames: ["test-corrupted.jpg", "plugin-test.png"],
-      },
-      entry: path.join(fixturesPath, "empty-entry.js"),
-      imageminPluginOptions: {
-        severityError: "auto",
         minimizerOptions: {
           plugins,
         },
@@ -175,68 +96,13 @@ describe("plugin severityError option", () => {
     const { compilation } = stats;
     const { warnings, errors } = compilation;
 
-    expect(warnings).toHaveLength(1);
-    expect(errors).toHaveLength(0);
-    expect(warnings[0].message).toMatch(
+    expect(warnings).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(
       /(Corrupt JPEG data|Command failed with EPIPE|Command failed with ENOTCONN)/
     );
 
     await expect(isOptimized("plugin-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
-  it("should optimizes images and throws error on corrupted images using mode `production` and `plugin.severityError` option with `auto` value (by plugin)", async () => {
-    const stats = await webpack({
-      mode: "production",
-      optimization: {
-        emitOnErrors: true,
-      },
-      emitPluginOptions: {
-        fileNames: ["test-corrupted.jpg", "plugin-test.png"],
-      },
-      entry: path.join(fixturesPath, "empty-entry.js"),
-      imageminPluginOptions: {
-        severityError: "auto",
-        minimizerOptions: {
-          plugins,
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
-
-    await expect(isOptimized("plugin-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
-  it("should optimizes images and throws errors on corrupted images using `plugin.severityError` option with `true` value (by loader)", async () => {
-    const stats = await webpack({
-      entry: path.join(fixturesPath, "loader-corrupted.js"),
-      imageminPluginOptions: {
-        severityError: true,
-        minimizerOptions: {
-          plugins,
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
-
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
       true
     );
   });
@@ -265,63 +131,10 @@ describe("plugin severityError option", () => {
     );
   });
 
-  it("should throws errors on corrupted images using mode `development` and `plugin.severityError` option with `auto` value (by loader)", async () => {
-    const stats = await webpack({
-      mode: "development",
-      entry: path.join(fixturesPath, "loader-corrupted.js"),
-      imageminPluginOptions: {
-        severityError: "auto",
-        minimizerOptions: {
-          plugins,
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(1);
-    expect(errors).toHaveLength(0);
-    expect(warnings[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
-
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
   it("should throws errors on corrupted images when `plugin.severityError` option not specify (by loader)", async () => {
     const stats = await webpack({
       entry: path.join(fixturesPath, "loader-corrupted.js"),
       imageminPluginOptions: {
-        minimizerOptions: {
-          plugins,
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(1);
-    expect(errors).toHaveLength(0);
-    expect(warnings[0].message).toMatch(
-      /(Corrupt JPEG data|Command failed with EPIPE)/
-    );
-
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
-  it("should throws errors on corrupted images using mode `production` and `plugin.severityError` option with `auto` value (by loader)", async () => {
-    const stats = await webpack({
-      mode: "production",
-      optimization: {
-        emitOnErrors: true,
-      },
-      entry: path.join(fixturesPath, "loader-corrupted.js"),
-      imageminPluginOptions: {
-        severityError: "auto",
         minimizerOptions: {
           plugins,
         },
@@ -346,27 +159,6 @@ describe("plugin severityError option", () => {
       entry: path.join(fixturesPath, "loader-corrupted.js"),
       imageminPluginOptions: {
         severityError: "off",
-        minimizerOptions: {
-          plugins,
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      true
-    );
-  });
-
-  it("should optimizes images and throws errors on corrupted images using `plugin.severityError` option with `false` value (by loader)", async () => {
-    const stats = await webpack({
-      entry: path.join(fixturesPath, "loader-corrupted.js"),
-      imageminPluginOptions: {
-        severityError: false,
         minimizerOptions: {
           plugins,
         },

--- a/test/validate-loader-options.test.js
+++ b/test/validate-loader-options.test.js
@@ -22,8 +22,8 @@ describe("validate loader options", () => {
       failure: [1, true, false, {}, [], null],
     },
     severityError: {
-      success: [true, false, "error"],
-      failure: [{}, [], () => {}],
+      success: ["error"],
+      failure: [true, false, {}, [], () => {}],
     },
     filename: {
       success: ["[name].[ext]"],

--- a/test/validate-plugin-options.test.js
+++ b/test/validate-plugin-options.test.js
@@ -129,11 +129,11 @@ describe("validate plugin options", () => {
 
     expect(() => {
       new ImageMinimizerPlugin({ severityError: false });
-    }).not.toThrow();
+    }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
       new ImageMinimizerPlugin({ severityError: true });
-    }).not.toThrow();
+    }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
       new ImageMinimizerPlugin({ severityError: "error" });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

`severityError` option reduced

### Breaking Changes

- Default value `severityError` option is "error"
- Values `true`, `false`, `auto` removed 

### Additional Info

No

