### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ $ npm install @squoosh/lib --save-dev
 **Recommended `@squoosh/lib` options for lossy optimization**
 
 For lossy optimization we recommend using the default settings `@squoosh/lib`.
-The default values and supported file types for each option can be found in the `[codecs.js]`(https://github.com/GoogleChromeLabs/squoosh/blob/dev/libsquoosh/src/codecs.js) file under `codecs`.
+The default values and supported file types for each option can be found in the `[codecs.ts]`(https://github.com/GoogleChromeLabs/squoosh/blob/dev/libsquoosh/src/codecs.ts) file under `codecs`.
 
 **webpack.config.js**
 


### PR DESCRIPTION
linked file was changed from js to ts in https://github.com/GoogleChromeLabs/squoosh/commit/1af5d1fa7bbb83013937ed96f630feb1d4b1fbe0
