### PR TITLE
refactor!: filename can be used only for minimizer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,17 +81,18 @@ import {
  * @property {TransformerFunction<T>} implementation
  * @property {FilterFn} [filter]
  * @property {string | FilenameFn} [filename]
+ * @property {string} [preset]
  * @property {T} [options]
  */
 
 /**
  * @template T
- * @typedef {Transformer<T>} Minimizer
+ * @typedef {Omit<Transformer<T>, "preset">} Minimizer
  */
 
 /**
  * @template T
- * @typedef {Transformer<T> & { preset: string }} Generator
+ * @typedef {Omit<Transformer<T>, "filename">} Generator
  */
 
 /**
@@ -115,7 +116,7 @@ import {
  * @property {Rules} [test] Test to match files against.
  * @property {Rules} [include] Files to include.
  * @property {Rules} [exclude] Files to exclude.
- * @property {Minimizer<T>} [minimizer] Allows to setup the minimizer.
+ * @property {Minimizer<T> | Minimizer<T>[]} [minimizer] Allows to setup the minimizer.
  * @property {Generator<T>[]} [generator] Allows to set the generator.
  * @property {boolean} [loader] Automatically adding `imagemin-loader`.
  * @property {number} [concurrency] Maximum number of concurrency optimization processes in one time.

--- a/src/loader-options.json
+++ b/src/loader-options.json
@@ -48,18 +48,6 @@
           "description": "Allows filtering of images.",
           "instanceof": "Function"
         },
-        "filename": {
-          "description": "Allows to set the filename for the generated asset.",
-          "anyOf": [
-            {
-              "type": "string",
-              "minLength": 1
-            },
-            {
-              "instanceof": "Function"
-            }
-          ]
-        },
         "options": {
           "description": "Options for the generator function.",
           "type": "object",

--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -79,18 +79,6 @@
           "description": "Allows filtering of images.",
           "instanceof": "Function"
         },
-        "filename": {
-          "description": "Allows to set the filename for the generated asset.",
-          "anyOf": [
-            {
-              "type": "string",
-              "minLength": 1
-            },
-            {
-              "instanceof": "Function"
-            }
-          ]
-        },
         "options": {
           "description": "Options for the generator function.",
           "type": "object",

--- a/test/__snapshots__/validate-loader-options.test.js.snap
+++ b/test/__snapshots__/validate-loader-options.test.js.snap
@@ -7,20 +7,10 @@ exports[`validate loader options should throw an error on the "generator" option
    -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#generator"
 `;
 
-exports[`validate loader options should throw an error on the "generator" option with "[{"preset":"webp","filename":true}]" value 1`] = `
-"Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
- - options.generator[0].filename should be one of these:
-   non-empty string | function
-   -> Allows to set the filename for the generated asset.
-   Details:
-    * options.generator[0].filename should be a non-empty string.
-    * options.generator[0].filename should be an instance of function."
-`;
-
 exports[`validate loader options should throw an error on the "generator" option with "{"preset":"webp","filter":true}" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options.generator should be an array:
-   [object { implementation, preset, filter?, filename?, options? }, ...] (should not have fewer than 1 item)
+   [object { implementation, preset, filter?, options? }, ...] (should not have fewer than 1 item)
    -> Allows you to setup the generator function and options.
    -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#generator"
 `;
@@ -28,7 +18,7 @@ exports[`validate loader options should throw an error on the "generator" option
 exports[`validate loader options should throw an error on the "generator" option with "{"preset":"webp"}" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options.generator should be an array:
-   [object { implementation, preset, filter?, filename?, options? }, ...] (should not have fewer than 1 item)
+   [object { implementation, preset, filter?, options? }, ...] (should not have fewer than 1 item)
    -> Allows you to setup the generator function and options.
    -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#generator"
 `;
@@ -36,7 +26,7 @@ exports[`validate loader options should throw an error on the "generator" option
 exports[`validate loader options should throw an error on the "generator" option with "1" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options.generator should be an array:
-   [object { implementation, preset, filter?, filename?, options? }, ...] (should not have fewer than 1 item)
+   [object { implementation, preset, filter?, options? }, ...] (should not have fewer than 1 item)
    -> Allows you to setup the generator function and options.
    -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#generator"
 `;
@@ -44,7 +34,7 @@ exports[`validate loader options should throw an error on the "generator" option
 exports[`validate loader options should throw an error on the "generator" option with "false" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options.generator should be an array:
-   [object { implementation, preset, filter?, filename?, options? }, ...] (should not have fewer than 1 item)
+   [object { implementation, preset, filter?, options? }, ...] (should not have fewer than 1 item)
    -> Allows you to setup the generator function and options.
    -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#generator"
 `;
@@ -52,7 +42,7 @@ exports[`validate loader options should throw an error on the "generator" option
 exports[`validate loader options should throw an error on the "generator" option with "null" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options.generator should be an array:
-   [object { implementation, preset, filter?, filename?, options? }, ...] (should not have fewer than 1 item)
+   [object { implementation, preset, filter?, options? }, ...] (should not have fewer than 1 item)
    -> Allows you to setup the generator function and options.
    -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#generator"
 `;
@@ -60,7 +50,7 @@ exports[`validate loader options should throw an error on the "generator" option
 exports[`validate loader options should throw an error on the "generator" option with "true" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options.generator should be an array:
-   [object { implementation, preset, filter?, filename?, options? }, ...] (should not have fewer than 1 item)
+   [object { implementation, preset, filter?, options? }, ...] (should not have fewer than 1 item)
    -> Allows you to setup the generator function and options.
    -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#generator"
 `;

--- a/test/__snapshots__/validate-plugin-options.test.js.snap
+++ b/test/__snapshots__/validate-plugin-options.test.js.snap
@@ -185,7 +185,7 @@ exports[`validate plugin options should work 15`] = `
 exports[`validate plugin options should work 16`] = `
 "Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
  - options.generator should be an array:
-   [object { implementation, preset, filter?, filename?, options? }, ...] (should not have fewer than 1 item)
+   [object { implementation, preset, filter?, options? }, ...] (should not have fewer than 1 item)
    -> Allows you to setup the generator function and options.
    -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#generator"
 `;
@@ -198,15 +198,9 @@ exports[`validate plugin options should work 17`] = `
 
 exports[`validate plugin options should work 18`] = `
 "Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
- - options.generator[0] misses the property 'implementation'. Should be:
-   function
-   -> Implementation of the generator function.
- - options.generator[0].filename should be one of these:
-   non-empty string | function
-   -> Allows to set the filename for the generated asset.
-   Details:
-    * options.generator[0].filename should be a non-empty string.
-    * options.generator[0].filename should be an instance of function."
+ - options.concurrency should be a number.
+   -> Number of concurrency optimization processes in one time.
+   -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#concurrency"
 `;
 
 exports[`validate plugin options should work 19`] = `
@@ -217,13 +211,6 @@ exports[`validate plugin options should work 19`] = `
 `;
 
 exports[`validate plugin options should work 20`] = `
-"Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
- - options.concurrency should be a number.
-   -> Number of concurrency optimization processes in one time.
-   -> Read more at https://github.com/webpack-contrib/image-minimizer-webpack-plugin#concurrency"
-`;
-
-exports[`validate plugin options should work 21`] = `
 "Invalid options object. Image Minimizer Plugin has been initialized using an options object that does not match the API schema.
  - options.loader should be a boolean.
    -> Automatically adding \`imagemin-loader\` (require for minification images using in \`url-loader\`, \`svg-url-loader\` or other).

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -130,7 +130,7 @@ function runWebpack(maybeOptions, getCompiler = false) {
         publicPath: "",
         filename: "bundle.js",
         pathinfo: false,
-        assetModuleFilename: "[name][ext]",
+        assetModuleFilename: options.name || "[name][ext]",
         path:
           options.output && options.output.path
             ? options.output.path

--- a/test/loader-generator-option.test.js
+++ b/test/loader-generator-option.test.js
@@ -114,15 +114,15 @@ describe("loader generator option", () => {
     );
   });
 
-  it("should generate the new webp image with flat filename", async () => {
+  it("should generate the new webp image with other name using old loader approach", async () => {
     const stats = await runWebpack({
       entry: path.join(fixturesPath, "./loader-single.js"),
+      name: "foo-[name].[ext]",
       imageminLoaderOptions: {
         generator: [
           {
             preset: "webp",
             implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: "[name].webp",
             options: {
               encodeOptions: {
                 webp: {
@@ -141,7 +141,7 @@ describe("loader generator option", () => {
     const transformedAsset = path.resolve(
       __dirname,
       compilation.options.output.path,
-      "loader-test.webp"
+      "foo-loader-test.webp"
     );
 
     const transformedExt = await fileType.fromFile(transformedAsset);
@@ -151,15 +151,17 @@ describe("loader generator option", () => {
     expect(errors).toHaveLength(0);
   });
 
-  it("should generate the new webp image with nested filename", async () => {
+  it("should generate the new webp image with other name using asset modules name", async () => {
     const stats = await runWebpack({
       entry: path.join(fixturesPath, "./loader-single.js"),
+      fileLoaderOff: true,
+      assetResource: true,
+      name: "foo-[name][ext]",
       imageminLoaderOptions: {
         generator: [
           {
             preset: "webp",
             implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: "deep/[path][name].webp",
             options: {
               encodeOptions: {
                 webp: {
@@ -171,119 +173,19 @@ describe("loader generator option", () => {
         ],
       },
     });
+
     const { compilation } = stats;
     const { warnings, errors } = compilation;
 
     const transformedAsset = path.resolve(
       __dirname,
       compilation.options.output.path,
-      "deep/nested/deep/loader-test.webp"
+      "foo-loader-test.webp"
     );
 
     const transformedExt = await fileType.fromFile(transformedAsset);
 
     expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-  });
-
-  it("should generate the new webp image with filename  pointing to other directory", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "./loader-single.js"),
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: "other/[name].webp",
-            options: {
-              encodeOptions: {
-                webp: {
-                  lossless: 1,
-                },
-              },
-            },
-          },
-        ],
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    const transformedAsset = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "other/loader-test.webp"
-    );
-
-    const transformedExt = await fileType.fromFile(transformedAsset);
-
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-  });
-
-  it("should generate the new webp image when filename is function", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "./loader-single.js"),
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: () => "other/[name].webp",
-            options: {
-              encodeOptions: {
-                webp: {
-                  lossless: 1,
-                },
-              },
-            },
-          },
-        ],
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    const transformedAsset = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "other/loader-test.webp"
-    );
-
-    const transformedExt = await fileType.fromFile(transformedAsset);
-
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-  });
-
-  it("should minimize image with flat filename", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "./simple.js"),
-      imageminLoaderOptions: {
-        minimizer: [
-          {
-            implementation: ImageMinimizerPlugin.squooshMinify,
-            filename: "[name][ext]",
-          },
-        ],
-      },
-    });
-
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    const transformedAsset = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "loader-test.jpg"
-    );
-
-    const transformedExt = await fileType.fromFile(transformedAsset);
-
-    expect(/image\/jpeg/i.test(transformedExt.mime)).toBe(true);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });

--- a/test/validate-loader-options.test.js
+++ b/test/validate-loader-options.test.js
@@ -115,20 +115,6 @@ describe("validate loader options", () => {
             filter: () => false,
           },
         ],
-        [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: "[name].[ext]",
-          },
-        ],
-        [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: () => "[name].[ext]",
-          },
-        ],
       ],
       failure: [
         1,
@@ -144,13 +130,6 @@ describe("validate loader options", () => {
           implementation: ImageMinimizerPlugin.squooshGenerate,
           filter: true,
         },
-        [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: true,
-          },
-        ],
       ],
     },
     severityError: {

--- a/test/validate-plugin-options.test.js
+++ b/test/validate-plugin-options.test.js
@@ -538,41 +538,6 @@ describe("validate plugin options", () => {
 
     expect(() => {
       new ImageMinimizerPlugin({
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: "[name].[ext]",
-          },
-        ],
-      });
-    }).not.toThrow();
-
-    expect(() => {
-      new ImageMinimizerPlugin({
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: () => "[name].[ext]",
-          },
-        ],
-      });
-    }).not.toThrow();
-
-    expect(() => {
-      new ImageMinimizerPlugin({
-        generator: [
-          {
-            preset: "webp",
-            filename: true,
-          },
-        ],
-      });
-    }).toThrowErrorMatchingSnapshot();
-
-    expect(() => {
-      new ImageMinimizerPlugin({
         concurrency: 2,
         minimizer: {
           implementation: ImageMinimizerPlugin.squooshMinify,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,12 +42,11 @@ export type Transformer<T> = {
   implementation: TransformerFunction<T>;
   filter?: FilterFn | undefined;
   filename?: string | FilenameFn | undefined;
+  preset?: string | undefined;
   options?: T | undefined;
 };
-export type Minimizer<T> = Transformer<T>;
-export type Generator<T> = Transformer<T> & {
-  preset: string;
-};
+export type Minimizer<T> = Omit<Transformer<T>, "preset">;
+export type Generator<T> = Omit<Transformer<T>, "filename">;
 export type InternalWorkerOptions<T> = {
   filename: string;
   input: Buffer;
@@ -72,7 +71,7 @@ export type PluginOptions<T> = {
   /**
    * Allows to setup the minimizer.
    */
-  minimizer?: Minimizer<T> | undefined;
+  minimizer?: Minimizer<T> | Minimizer<T>[] | undefined;
   /**
    * Allows to set the generator.
    */
@@ -150,15 +149,16 @@ export type PluginOptions<T> = {
  * @property {TransformerFunction<T>} implementation
  * @property {FilterFn} [filter]
  * @property {string | FilenameFn} [filename]
+ * @property {string} [preset]
  * @property {T} [options]
  */
 /**
  * @template T
- * @typedef {Transformer<T>} Minimizer
+ * @typedef {Omit<Transformer<T>, "preset">} Minimizer
  */
 /**
  * @template T
- * @typedef {Transformer<T> & { preset: string }} Generator
+ * @typedef {Omit<Transformer<T>, "filename">} Generator
  */
 /**
  * @template T
@@ -179,7 +179,7 @@ export type PluginOptions<T> = {
  * @property {Rules} [test] Test to match files against.
  * @property {Rules} [include] Files to include.
  * @property {Rules} [exclude] Files to exclude.
- * @property {Minimizer<T>} [minimizer] Allows to setup the minimizer.
+ * @property {Minimizer<T> | Minimizer<T>[]} [minimizer] Allows to setup the minimizer.
  * @property {Generator<T>[]} [generator] Allows to set the generator.
  * @property {boolean} [loader] Automatically adding `imagemin-loader`.
  * @property {number} [concurrency] Maximum number of concurrency optimization processes in one time.

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -26,6 +26,11 @@ export type MetaData = {
  */
 export function throttleAll<T>(limit: number, tasks: Task<T>[]): Promise<T[]>;
 /**
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isAbsoluteURL(url: string): boolean;
+/**
  * @template T
  * @param {ImageminOptions} imageminConfig
  * @returns {Promise<ImageminOptions>}


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

because we affect only on `extension` for generator, developer should use `assetModulePath` or loader name for naming module, we should not have ability to have it, it is out of scope our plugin

### Breaking Changes

Yes

### Additional Info

No