### PR TITLE
fix: double minification and memory leak

### DIFF
--- a/test/fixtures/single-image-loader.js
+++ b/test/fixtures/single-image-loader.js
@@ -1,1 +1,1 @@
-require("./loader-test.jpg");
+require("./loader-test.jpg?as=webp");

--- a/test/plugin-severityError-option.test.js
+++ b/test/plugin-severityError-option.test.js
@@ -127,8 +127,14 @@ describe("plugin severityError option", () => {
     const { warnings, errors } = compilation;
 
     expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(1);
+    expect(errors).toHaveLength(2);
+
+    // From loader
     expect(errors[0].message).toMatch(
+      /(Corrupt JPEG data|Command failed with EPIPE)/
+    );
+    // From plugin
+    expect(errors[1].message).toMatch(
       /(Corrupt JPEG data|Command failed with EPIPE)/
     );
 
@@ -151,8 +157,14 @@ describe("plugin severityError option", () => {
     const { warnings, errors } = compilation;
 
     expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(1);
+    expect(errors).toHaveLength(2);
+
+    // From loader
     expect(errors[0].message).toMatch(
+      /(Corrupt JPEG data|Command failed with EPIPE)/
+    );
+    // From plugin
+    expect(errors[1].message).toMatch(
       /(Corrupt JPEG data|Command failed with EPIPE)/
     );
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fix double minification and memory leak,w e support old loaders, like `file-loader`, and asset modules

### Breaking Changes

No

### Additional Info

No