### PR TITLE
feat: removed cjs wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "type": "opencollective",
     "url": "https://opencollective.com/webpack"
   },
-  "main": "dist/cjs.js",
-  "types": "types/cjs.d.ts",
+  "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">= 12.13.0"
   },
   "scripts": {
     "start": "npm run build -- -w",
-    "clean": "del-cli dist",
+    "clean": "del-cli dist types",
     "prebuild": "npm run clean",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,1 +1,0 @@
-module.exports = require("./index").default;

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,19 @@
-import * as path from "path";
-import * as os from "os";
+const path = require("path");
+const os = require("os");
 
-import { validate } from "schema-utils";
-import serialize from "serialize-javascript";
+const { validate } = require("schema-utils");
+const serialize = require("serialize-javascript");
 
-import worker from "./worker";
-import schema from "./plugin-options.json";
-import {
+const worker = require("./worker");
+const schema = require("./plugin-options.json");
+const {
   throttleAll,
   imageminNormalizeConfig,
   imageminMinify,
   imageminGenerate,
   squooshMinify,
   squooshGenerate,
-} from "./utils.js";
+} = require("./utils.js");
 
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").WebpackPluginInstance} WebpackPluginInstance */
@@ -515,4 +515,4 @@ ImageMinimizerPlugin.imageminGenerate = imageminGenerate;
 ImageMinimizerPlugin.squooshMinify = squooshMinify;
 ImageMinimizerPlugin.squooshGenerate = squooshGenerate;
 
-export default ImageMinimizerPlugin;
+module.exports = ImageMinimizerPlugin;

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,8 +1,8 @@
-import path from "path";
+const path = require("path");
 
-import worker from "./worker";
-import schema from "./loader-options.json";
-import { isAbsoluteURL } from "./utils.js";
+const worker = require("./worker");
+const schema = require("./loader-options.json");
+const { isAbsoluteURL } = require("./utils.js");
 
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compilation} Compilation */

--- a/src/loader.js
+++ b/src/loader.js
@@ -19,8 +19,9 @@ const { isAbsoluteURL } = require("./utils.js");
  * @template T
  * @this {import("webpack").LoaderContext<LoaderOptions<T>>}
  * @param {Buffer} content
+ * @returns {Promise<Buffer | undefined>}
  */
-module.exports = async function loader(content) {
+async function loader(content) {
   // Avoid optimize twice
   if (
     this._module &&
@@ -170,6 +171,8 @@ module.exports = async function loader(content) {
   }
 
   callback(null, output.data);
-};
+}
 
-module.exports.raw = true;
+loader.raw = true;
+
+module.exports = loader;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import path from "path";
+const path = require("path");
 
 /** @typedef {import("./index").WorkerResult} WorkerResult */
 /** @typedef {import("./index").SquooshOptions} SquooshOptions */
@@ -927,7 +927,7 @@ squooshMinify.setup = squooshImagePoolSetup;
 
 squooshMinify.teardown = squooshImagePoolTeardown;
 
-export {
+module.exports = {
   throttleAll,
   isAbsoluteURL,
   imageminNormalizeConfig,

--- a/src/worker.js
+++ b/src/worker.js
@@ -6,7 +6,7 @@
  * @param {import("./index").InternalWorkerOptions<T>} options
  * @returns {Promise<WorkerResult>}
  */
-export default async function worker(options) {
+async function worker(options) {
   /** @type {WorkerResult} */
   let result = {
     data: options.input,
@@ -117,3 +117,5 @@ export default async function worker(options) {
 
   return result;
 }
+
+module.exports = worker;

--- a/test/cjs.test.js
+++ b/test/cjs.test.js
@@ -1,8 +1,0 @@
-import src from "../src";
-import cjs from "../src/cjs";
-
-describe("cjs", () => {
-  it("should export loader", () => {
-    expect(cjs).toEqual(src);
-  });
-});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -10,12 +10,8 @@ import pify from "pify";
 
 import worker from "../src/worker";
 
-import {
-  imageminMinify,
-  imageminGenerate,
-  squooshMinify,
-  squooshGenerate,
-} from "../src/utils.js";
+// eslint-disable-next-line import/default
+import utils from "../src/utils.js";
 
 function isPromise(obj) {
   return (
@@ -34,7 +30,7 @@ describe("minify", () => {
       isPromise(
         worker({
           transformer: {
-            implementation: imageminMinify,
+            implementation: utils.imageminMinify,
             options: { plugins: ["mozjpeg"] },
           },
         })
@@ -48,7 +44,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: { plugins: ["mozjpeg"] },
       },
     });
@@ -71,7 +67,7 @@ describe("minify", () => {
       input,
       filename: path.relative(process.cwd(), filename),
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: { plugins: ["mozjpeg"] },
       },
     });
@@ -109,7 +105,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: { plugins: [["svgo", svgoOptions]] },
       },
     });
@@ -141,7 +137,7 @@ describe("minify", () => {
     const result = await worker({
       input,
       filename,
-      transformer: { implementation: imageminMinify },
+      transformer: { implementation: utils.imageminMinify },
     });
 
     expect(result.warnings).toHaveLength(0);
@@ -160,7 +156,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: { plugins: [] },
       },
     });
@@ -181,7 +177,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: { plugins: false },
       },
     });
@@ -202,7 +198,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: ["imagemin-mozjpeg", "unknown"],
         },
@@ -224,7 +220,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: ["imagemin-unknown"],
         },
@@ -246,7 +242,7 @@ describe("minify", () => {
       input,
       filename: "foo.jpg",
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: ["mozjpeg"],
         },
@@ -265,7 +261,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: ["mozjpeg"],
         },
@@ -290,7 +286,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: ["mozjpeg"],
         },
@@ -315,7 +311,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: [["mozjpeg", { quality: 0 }]],
         },
@@ -340,7 +336,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: [["mozjpeg"]],
         },
@@ -362,11 +358,11 @@ describe("minify", () => {
     const filename = path.resolve(__dirname, "./fixtures/loader-test.jpg");
     const input = await pify(fs.readFile)(filename);
     const result = await worker({
-      minify: imageminMinify,
+      minify: utils.imageminMinify,
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: ["imagemin-mozjpeg"],
         },
@@ -388,11 +384,11 @@ describe("minify", () => {
     const filename = path.resolve(__dirname, "./fixtures/loader-test.jpg");
     const input = await pify(fs.readFile)(filename);
     const result = await worker({
-      minify: imageminMinify,
+      minify: utils.imageminMinify,
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: [["imagemin-mozjpeg", { quality: 0 }]],
         },
@@ -417,7 +413,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: [["imagemin-mozjpeg"]],
         },
@@ -442,7 +438,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: [imageminMozjpeg()],
         },
@@ -474,7 +470,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: [["svgo", svgoOptions]],
         },
@@ -533,7 +529,7 @@ describe("minify", () => {
           },
         },
         {
-          implementation: squooshMinify,
+          implementation: utils.squooshMinify,
           options: {
             encodeOptions: {
               mozjpeg: {
@@ -573,7 +569,7 @@ describe("minify", () => {
       filename,
       transformer: [
         {
-          implementation: squooshMinify,
+          implementation: utils.squooshMinify,
           options: {
             encodeOptions: {
               mozjpeg: {
@@ -619,7 +615,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: ["imagemin-mozjpeg"],
         },
@@ -640,11 +636,11 @@ describe("minify", () => {
     const filename = path.resolve(__dirname, "./fixtures/loader-test.jpg");
     const input = await pify(fs.readFile)(filename);
     const result = await worker({
-      minify: imageminMinify,
+      minify: utils.imageminMinify,
       input,
       filename,
       transformer: {
-        implementation: imageminMinify,
+        implementation: utils.imageminMinify,
         options: {
           plugins: [],
         },
@@ -665,7 +661,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminGenerate,
+        implementation: utils.imageminGenerate,
         options: {
           plugins: ["imagemin-webp"],
         },
@@ -689,7 +685,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminGenerate,
+        implementation: utils.imageminGenerate,
         options: {
           plugins: [["imagemin-webp", { quality: 90 }]],
         },
@@ -713,7 +709,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: imageminGenerate,
+        implementation: utils.imageminGenerate,
         options: { plugins: [] },
       },
     });
@@ -732,7 +728,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: squooshMinify,
+        implementation: utils.squooshMinify,
         options: {
           encodeOptions: {
             mozjpeg: {
@@ -769,7 +765,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: squooshGenerate,
+        implementation: utils.squooshGenerate,
         options: {
           encodeOptions: {
             webp: {
@@ -806,7 +802,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: squooshGenerate,
+        implementation: utils.squooshGenerate,
         options: {},
       },
     });
@@ -826,7 +822,7 @@ describe("minify", () => {
       filename,
       generateFilename: () => "generated-image.png",
       transformer: {
-        implementation: squooshMinify,
+        implementation: utils.squooshMinify,
         filename: "generated-image.png",
         options: {
           encodeOptions: {
@@ -867,7 +863,7 @@ describe("minify", () => {
       generateFilename: (_, info) => `generated-${info.filename}`,
       transformer: [
         {
-          implementation: squooshMinify,
+          implementation: utils.squooshMinify,
           filename: "image.jpg",
           options: {
             encodeOptions: {
@@ -878,7 +874,7 @@ describe("minify", () => {
           },
         },
         {
-          implementation: squooshMinify,
+          implementation: utils.squooshMinify,
           filename: "image.jpg",
           options: {
             encodeOptions: {
@@ -918,7 +914,7 @@ describe("minify", () => {
       input,
       filename,
       transformer: {
-        implementation: squooshMinify,
+        implementation: utils.squooshMinify,
         filter: () => false,
         options: {
           encodeOptions: {

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -1,2 +1,0 @@
-declare const _exports: typeof import("./index").default;
-export = _exports;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,116 +1,4 @@
-export default ImageMinimizerPlugin;
-export type Schema = import("schema-utils/declarations/validate").Schema;
-export type WebpackPluginInstance = import("webpack").WebpackPluginInstance;
-export type Compiler = import("webpack").Compiler;
-export type Compilation = import("webpack").Compilation;
-export type WebpackError = import("webpack").WebpackError;
-export type Asset = import("webpack").Asset;
-export type AssetInfo = import("webpack").AssetInfo;
-export type ImageminMinifyFunction = typeof imageminMinify;
-export type SquooshMinifyFunction = typeof squooshMinify;
-export type Rule = RegExp | string;
-export type Rules = Rule[] | Rule;
-export type FilterFn = (source: Buffer, sourcePath: string) => boolean;
-export type ImageminOptions = {
-  plugins: Array<
-    string | [string, Record<string, any>?] | import("imagemin").Plugin
-  >;
-};
-export type SquooshOptions = {
-  [x: string]: any;
-};
-export type WorkerResult = {
-  filename: string;
-  data: Buffer;
-  warnings: Array<Error>;
-  errors: Array<Error>;
-  info: AssetInfo;
-};
-export type CustomOptions = {
-  [key: string]: any;
-};
-export type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
-export type BasicTransformerOptions<T> = InferDefaultType<T> | undefined;
-export type BasicTransformerImplementation<T> = (
-  original: WorkerResult,
-  options?: BasicTransformerOptions<T>
-) => Promise<WorkerResult>;
-export type BasicTransformerHelpers = {
-  setup?: (() => {}) | undefined;
-  teardown?: (() => {}) | undefined;
-};
-export type TransformerFunction<T> = BasicTransformerImplementation<T> &
-  BasicTransformerHelpers;
-export type PathData = {
-  filename?: string | undefined;
-};
-export type FilenameFn = (
-  pathData: PathData,
-  assetInfo?: import("webpack").AssetInfo | undefined
-) => string;
-export type Transformer<T> = {
-  implementation: TransformerFunction<T>;
-  options?: BasicTransformerOptions<T>;
-  filter?: FilterFn | undefined;
-  filename?: string | FilenameFn | undefined;
-  preset?: string | undefined;
-};
-export type Minimizer<T> = Omit<Transformer<T>, "preset">;
-export type Generator<T> = Transformer<T>;
-export type InternalWorkerOptions<T> = {
-  filename: string;
-  input: Buffer;
-  transformer: Transformer<T> | Transformer<T>[];
-  severityError?: string | undefined;
-  generateFilename?: Function | undefined;
-};
-export type InternalLoaderOptions<T> = import("./loader").LoaderOptions<T>;
-export type PluginOptions<T, G> = {
-  /**
-   * Test to match files against.
-   */
-  test?: Rules | undefined;
-  /**
-   * Files to include.
-   */
-  include?: Rules | undefined;
-  /**
-   * Files to exclude.
-   */
-  exclude?: Rules | undefined;
-  /**
-   * Allows to setup the minimizer.
-   */
-  minimizer?:
-    | (T extends any[]
-        ? { [P in keyof T]: Minimizer<T[P]> }
-        : Minimizer<T> | Minimizer<T>[])
-    | undefined;
-  /**
-   * Allows to set the generator.
-   */
-  generator?:
-    | (G extends any[]
-        ? { [P_1 in keyof G]: Generator<G[P_1]> }
-        : Generator<G>[])
-    | undefined;
-  /**
-   * Automatically adding `imagemin-loader`.
-   */
-  loader?: boolean | undefined;
-  /**
-   * Maximum number of concurrency optimization processes in one time.
-   */
-  concurrency?: number | undefined;
-  /**
-   * Allows to choose how errors are displayed.
-   */
-  severityError?: string | undefined;
-  /**
-   * Allows to remove original assets. Useful for converting to a `webp` and remove original assets.
-   */
-  deleteOriginalAssets?: boolean | undefined;
-};
+export = ImageMinimizerPlugin;
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").WebpackPluginInstance} WebpackPluginInstance */
 /** @typedef {import("webpack").Compiler} Compiler */
@@ -258,15 +146,159 @@ declare class ImageMinimizerPlugin<T, G = T> {
   apply(compiler: import("webpack").Compiler): void;
 }
 declare namespace ImageMinimizerPlugin {
-  export const loader: string;
-  export { imageminNormalizeConfig };
-  export { imageminMinify };
-  export { imageminGenerate };
-  export { squooshMinify };
-  export { squooshGenerate };
+  export {
+    loader,
+    imageminNormalizeConfig,
+    imageminMinify,
+    imageminGenerate,
+    squooshMinify,
+    squooshGenerate,
+    Schema,
+    WebpackPluginInstance,
+    Compiler,
+    Compilation,
+    WebpackError,
+    Asset,
+    AssetInfo,
+    ImageminMinifyFunction,
+    SquooshMinifyFunction,
+    Rule,
+    Rules,
+    FilterFn,
+    ImageminOptions,
+    SquooshOptions,
+    WorkerResult,
+    CustomOptions,
+    InferDefaultType,
+    BasicTransformerOptions,
+    BasicTransformerImplementation,
+    BasicTransformerHelpers,
+    TransformerFunction,
+    PathData,
+    FilenameFn,
+    Transformer,
+    Minimizer,
+    Generator,
+    InternalWorkerOptions,
+    InternalLoaderOptions,
+    PluginOptions,
+  };
 }
-import { imageminMinify } from "./utils.js";
-import { squooshMinify } from "./utils.js";
+type PluginOptions<T, G> = {
+  /**
+   * Test to match files against.
+   */
+  test?: Rules | undefined;
+  /**
+   * Files to include.
+   */
+  include?: Rules | undefined;
+  /**
+   * Files to exclude.
+   */
+  exclude?: Rules | undefined;
+  /**
+   * Allows to setup the minimizer.
+   */
+  minimizer?:
+    | (T extends any[]
+        ? { [P in keyof T]: Minimizer<T[P]> }
+        : Minimizer<T> | Minimizer<T>[])
+    | undefined;
+  /**
+   * Allows to set the generator.
+   */
+  generator?:
+    | (G extends any[]
+        ? { [P_1 in keyof G]: Generator<G[P_1]> }
+        : Generator<G>[])
+    | undefined;
+  /**
+   * Automatically adding `imagemin-loader`.
+   */
+  loader?: boolean | undefined;
+  /**
+   * Maximum number of concurrency optimization processes in one time.
+   */
+  concurrency?: number | undefined;
+  /**
+   * Allows to choose how errors are displayed.
+   */
+  severityError?: string | undefined;
+  /**
+   * Allows to remove original assets. Useful for converting to a `webp` and remove original assets.
+   */
+  deleteOriginalAssets?: boolean | undefined;
+};
+declare var loader: string;
 import { imageminNormalizeConfig } from "./utils.js";
+import { imageminMinify } from "./utils.js";
 import { imageminGenerate } from "./utils.js";
+import { squooshMinify } from "./utils.js";
 import { squooshGenerate } from "./utils.js";
+type Schema = import("schema-utils/declarations/validate").Schema;
+type WebpackPluginInstance = import("webpack").WebpackPluginInstance;
+type Compiler = import("webpack").Compiler;
+type Compilation = import("webpack").Compilation;
+type WebpackError = import("webpack").WebpackError;
+type Asset = import("webpack").Asset;
+type AssetInfo = import("webpack").AssetInfo;
+type ImageminMinifyFunction = typeof imageminMinify;
+type SquooshMinifyFunction = typeof squooshMinify;
+type Rule = RegExp | string;
+type Rules = Rule[] | Rule;
+type FilterFn = (source: Buffer, sourcePath: string) => boolean;
+type ImageminOptions = {
+  plugins: Array<
+    string | [string, Record<string, any>?] | import("imagemin").Plugin
+  >;
+};
+type SquooshOptions = {
+  [x: string]: any;
+};
+type WorkerResult = {
+  filename: string;
+  data: Buffer;
+  warnings: Array<Error>;
+  errors: Array<Error>;
+  info: AssetInfo;
+};
+type CustomOptions = {
+  [key: string]: any;
+};
+type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
+type BasicTransformerOptions<T> = InferDefaultType<T> | undefined;
+type BasicTransformerImplementation<T> = (
+  original: WorkerResult,
+  options?: BasicTransformerOptions<T>
+) => Promise<WorkerResult>;
+type BasicTransformerHelpers = {
+  setup?: (() => {}) | undefined;
+  teardown?: (() => {}) | undefined;
+};
+type TransformerFunction<T> = BasicTransformerImplementation<T> &
+  BasicTransformerHelpers;
+type PathData = {
+  filename?: string | undefined;
+};
+type FilenameFn = (
+  pathData: PathData,
+  assetInfo?: import("webpack").AssetInfo | undefined
+) => string;
+type Transformer<T> = {
+  implementation: TransformerFunction<T>;
+  options?: BasicTransformerOptions<T>;
+  filter?: FilterFn | undefined;
+  filename?: string | FilenameFn | undefined;
+  preset?: string | undefined;
+};
+type Minimizer<T> = Omit<Transformer<T>, "preset">;
+type Generator<T> = Transformer<T>;
+type InternalWorkerOptions<T> = {
+  filename: string;
+  input: Buffer;
+  transformer: Transformer<T> | Transformer<T>[];
+  severityError?: string | undefined;
+  generateFilename?: Function | undefined;
+};
+type InternalLoaderOptions<T> = import("./loader").LoaderOptions<T>;

--- a/types/loader.d.ts
+++ b/types/loader.d.ts
@@ -1,9 +1,50 @@
-export type Schema = import("schema-utils/declarations/validate").Schema;
-export type Compilation = import("webpack").Compilation;
+export = loader;
+/** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
+/** @typedef {import("webpack").Compilation} Compilation */
+/**
+ * @template T
+ * @typedef {Object} LoaderOptions<T>
+ * @property {string} [severityError] Allows to choose how errors are displayed.
+ * @property {import("./index").Minimizer<T> | import("./index").Minimizer<T>[]} [minimizer]
+ * @property {import("./index").Generator<T>[]} [generator]
+ */
+/**
+ * @template T
+ * @this {import("webpack").LoaderContext<LoaderOptions<T>>}
+ * @param {Buffer} content
+ * @returns {Promise<Buffer | undefined>}
+ */
+declare function loader<T>(content: Buffer): Promise<Buffer | undefined>;
+declare class loader<T> {
+  /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
+  /** @typedef {import("webpack").Compilation} Compilation */
+  /**
+   * @template T
+   * @typedef {Object} LoaderOptions<T>
+   * @property {string} [severityError] Allows to choose how errors are displayed.
+   * @property {import("./index").Minimizer<T> | import("./index").Minimizer<T>[]} [minimizer]
+   * @property {import("./index").Generator<T>[]} [generator]
+   */
+  /**
+   * @template T
+   * @this {import("webpack").LoaderContext<LoaderOptions<T>>}
+   * @param {Buffer} content
+   * @returns {Promise<Buffer | undefined>}
+   */
+  constructor(content: Buffer);
+  resourcePath: string | undefined;
+  resourceQuery: string | undefined;
+}
+declare namespace loader {
+  export { raw, Schema, Compilation, LoaderOptions };
+}
+declare var raw: boolean;
+type Schema = import("schema-utils/declarations/validate").Schema;
+type Compilation = import("webpack").Compilation;
 /**
  * <T>
  */
-export type LoaderOptions<T> = {
+type LoaderOptions<T> = {
   /**
    * Allows to choose how errors are displayed.
    */

--- a/types/worker.d.ts
+++ b/types/worker.d.ts
@@ -1,3 +1,4 @@
+export = worker;
 /** @typedef {import("./index").WorkerResult} WorkerResult */
 /** @typedef {import("./index").FilenameFn} FilenameFn */
 /**
@@ -5,8 +6,11 @@
  * @param {import("./index").InternalWorkerOptions<T>} options
  * @returns {Promise<WorkerResult>}
  */
-export default function worker<T>(
+declare function worker<T>(
   options: import("./index").InternalWorkerOptions<T>
 ): Promise<WorkerResult>;
-export type WorkerResult = import("./index").WorkerResult;
-export type FilenameFn = import("./index").FilenameFn;
+declare namespace worker {
+  export { WorkerResult, FilenameFn };
+}
+type WorkerResult = import("./index").WorkerResult;
+type FilenameFn = import("./index").FilenameFn;


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

removed cjs wrapper and generated types in commonjs format (`export =` and `namespaces` used in types), now you can directly use exported types

### Breaking Changes

Potentially yes, but we use `babel` and our code in commonjs format, but types in ESM, so it is fix

### Additional Info

No