### PR TITLE
Remove usage of deprecated `extendDefaultPlugins` in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ For `imagemin-svgo` v9.0.0+ need use svgo [configuration](https://github.com/svg
 
 ```js
 const ImageMinimizerPlugin = require("image-minimizer-webpack-plugin");
-const { extendDefaultPlugins } = require("svgo");
 
 module.exports = {
   module: {
@@ -108,18 +107,23 @@ module.exports = {
               [
                 "svgo",
                 {
-                  plugins: extendDefaultPlugins([
+                  plugins: [
                     {
-                      name: "removeViewBox",
-                      active: false,
-                    },
-                    {
-                      name: "addAttributesToSVGElement",
+                      name: "preset-default",
                       params: {
-                        attributes: [{ xmlns: "http://www.w3.org/2000/svg" }],
+                        overrides: {
+                          removeViewBox: false,
+                          addAttributesToSVGElement: {
+                            params: {
+                              attributes: [
+                                { xmlns: "http://www.w3.org/2000/svg" },
+                              ],
+                            },
+                          },
+                        },
                       },
                     },
-                  ]),
+                  ],
                 },
               ],
             ],


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [X] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The original config example uses `extendDefaultPlugins`. This creates a warning when running webpack on the config.

### Breaking Changes

Just doc :-) 

### Additional Info
I was not 100% sure how to pass the param to `addAttributesToSVGElement`. Is the new structure equivalent to the old one?