### PR TITLE
docs: rename option `mozjpeg` -> `jpeg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ module.exports = {
           // Options
           options: {
             encodeOptions: {
-              mozjpeg: {
+              jpeg: {
                 quality: 90,
               },
             },


### PR DESCRIPTION
Sharp accepts `jpg` or `jpeg` as output format, but not `mozjpeg`

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**
