### PR TITLE
fix: better fix for #334

### DIFF
--- a/test/loader-generator-option.test.js
+++ b/test/loader-generator-option.test.js
@@ -6,6 +6,8 @@ import ImageMinimizerPlugin from "../src";
 
 import { runWebpack, fixturesPath } from "./helpers";
 
+jest.setTimeout(10000);
+
 describe("loader generator option", () => {
   it("should work", async () => {
     const stats = await runWebpack({

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -250,7 +250,7 @@ describe("minify", () => {
     });
 
     expect(result.warnings).toHaveLength(0);
-    expect(result.errors).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
     expect(result.data).toBe(input);
   });
 
@@ -889,7 +889,7 @@ describe("minify", () => {
 
     expect(result.warnings).toHaveLength(0);
     expect(result.errors).toHaveLength(0);
-    expect(result.filename).toBe("generated-generated-image.jpg");
+    expect(result.filename).toBe("generated-image.jpg");
 
     const imagePool = new ImagePool(1);
     const image = imagePool.ingestImage(new Uint8Array(input));

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -68,32 +68,32 @@ export function imageminNormalizeConfig<T>(
  * @template T
  * @param {WorkerResult} original
  * @param {T} options
- * @returns {Promise<WorkerResult>}
+ * @returns {Promise<WorkerResult | null>}
  */
 export function imageminMinify<T>(
   original: WorkerResult,
   options: T
-): Promise<WorkerResult>;
+): Promise<WorkerResult | null>;
 /**
  * @template T
  * @param {WorkerResult} original
  * @param {T} minimizerOptions
- * @returns {Promise<WorkerResult>}
+ * @returns {Promise<WorkerResult | null>}
  */
 export function imageminGenerate<T>(
   original: WorkerResult,
   minimizerOptions: T
-): Promise<WorkerResult>;
+): Promise<WorkerResult | null>;
 /**
  * @template T
  * @param {WorkerResult} original
  * @param {T} options
- * @returns {Promise<WorkerResult>}
+ * @returns {Promise<WorkerResult | null>}
  */
 export function squooshMinify<T>(
   original: WorkerResult,
   options: T
-): Promise<WorkerResult>;
+): Promise<WorkerResult | null>;
 export namespace squooshMinify {
   export { squooshImagePoolSetup as setup };
   export { squooshImagePoolTeardown as teardown };
@@ -102,12 +102,12 @@ export namespace squooshMinify {
  * @template T
  * @param {WorkerResult} original
  * @param {T} minifyOptions
- * @returns {Promise<WorkerResult>}
+ * @returns {Promise<WorkerResult | null>}
  */
 export function squooshGenerate<T>(
   original: WorkerResult,
   minifyOptions: T
-): Promise<WorkerResult>;
+): Promise<WorkerResult | null>;
 export namespace squooshGenerate {
   export { squooshImagePoolSetup as setup };
   export { squooshImagePoolTeardown as teardown };
@@ -116,22 +116,22 @@ export namespace squooshGenerate {
  * @template T
  * @param {WorkerResult} original
  * @param {T} minimizerOptions
- * @returns {Promise<WorkerResult>}
+ * @returns {Promise<WorkerResult | null>}
  */
 export function sharpMinify<T>(
   original: WorkerResult,
   minimizerOptions: T
-): Promise<WorkerResult>;
+): Promise<WorkerResult | null>;
 /**
  * @template T
  * @param {WorkerResult} original
  * @param {T} minimizerOptions
- * @returns {Promise<WorkerResult>}
+ * @returns {Promise<WorkerResult | null>}
  */
 export function sharpGenerate<T>(
   original: WorkerResult,
   minimizerOptions: T
-): Promise<WorkerResult>;
+): Promise<WorkerResult | null>;
 declare function squooshImagePoolSetup(): void;
 declare function squooshImagePoolTeardown(): Promise<void>;
 export {};


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Makes possible to use minimizer/generator `filename` option with unsupported formats or [multiple minimizers](https://github.com/webpack-contrib/image-minimizer-webpack-plugin#array)

### Breaking Changes
Implementation should return `Promise<null>` for unprocessed data now. But worker still returns not nullable `Promise<WorkerResult>`.

### Additional Info
