### PR TITLE
chore: move typescript `outDir` option to tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "npm run build -- -w",
     "clean": "del-cli dist types",
     "prebuild": "npm run clean",
-    "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write",
+    "build:types": "tsc --declaration --emitDeclarationOnly && prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",
     "build": "npm-run-all -p \"build:**\"",
     "commitlint": "commitlint --from=master",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "types": ["node"],
     "resolveJsonModule": true,
     "newLine": "LF",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "outDir": "./types"
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

The built-in linters of VSCode and Visual Studio emmit the error: `Typescript error "Cannot write file ... because it would overwrite input file."` if there is no `outDir` option in tsconfig.json

https://stackoverflow.com/q/55484557
https://stackoverflow.com/q/42609768
