### PR TITLE
chore: add timeout to github test action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -67,6 +67,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    timeout-minutes: 10
+
     steps:
       - name: Setup Git
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Sometimes the time of test actions takes up to 6 hours on windows. https://github.com/webpack-contrib/image-minimizer-webpack-plugin/actions/runs/3008820772/usage

It might be better to limit to 10 minutes.
