### PR TITLE
feat: add `width` and `height` placeholders in filename option

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -798,6 +798,7 @@ async function squooshGenerate(original, minifyOptions) {
   }
 
   const { binary, extension } = await Object.values(image.encodedWith)[0];
+  const { width, height } = (await image.decoded).bitmap;
   const { dir: fileDir, name: fileName } = path.parse(original.filename);
   const filename = path.join(fileDir, `${fileName}.${extension}`);
 
@@ -808,6 +809,8 @@ async function squooshGenerate(original, minifyOptions) {
     errors: [...original.errors],
     info: {
       ...original.info,
+      width,
+      height,
       generated: true,
       generatedBy: ["squoosh", ...(original.info?.generatedBy ?? [])],
     },
@@ -903,6 +906,7 @@ async function squooshMinify(original, options) {
   }
 
   const { binary } = await image.encodedWith[targets[ext]];
+  const { width, height } = (await image.decoded).bitmap;
 
   return {
     filename: original.filename,
@@ -911,6 +915,8 @@ async function squooshMinify(original, options) {
     errors: [...original.errors],
     info: {
       ...original.info,
+      width,
+      height,
       minimized: true,
       minimizedBy: ["squoosh", ...(original.info?.minimizedBy ?? [])],
     },
@@ -947,13 +953,7 @@ squooshMinify.teardown = squooshImagePoolTeardown;
  * @type {object}
  * @property {ResizeOptions} [resize]
  * @property {number | 'auto'} [rotate]
- * @property {SizeSuffix} [sizeSuffix]
  * @property {SharpEncodeOptions} [encodeOptions]
- */
-
-/**
- * @typedef SizeSuffix
- * @type {(width: number, height: number) => string}
  */
 
 // https://github.com/lovell/sharp/blob/e40a881ab4a5e7b0e37ba17e31b3b186aef8cbf6/lib/output.js#L7-L23
@@ -1038,12 +1038,7 @@ async function sharpTransform(
   const { dir: fileDir, name: fileName } = path.parse(original.filename);
 
   const { width, height } = result.info;
-  const sizeSuffix =
-    typeof minimizerOptions.sizeSuffix === "function"
-      ? minimizerOptions.sizeSuffix(width, height)
-      : "";
-
-  const filename = path.join(fileDir, `${fileName}${sizeSuffix}.${outputExt}`);
+  const filename = path.join(fileDir, `${fileName}.${outputExt}`);
   const processedFlag = targetFormat ? "generated" : "minimized";
   const processedBy = targetFormat ? "generatedBy" : "minimizedBy";
 
@@ -1054,6 +1049,8 @@ async function sharpTransform(
     errors: [...original.errors],
     info: {
       ...original.info,
+      width,
+      height,
       [processedFlag]: true,
       [processedBy]: ["sharp", ...(original.info?.[processedBy] ?? [])],
     },

--- a/src/worker.js
+++ b/src/worker.js
@@ -20,6 +20,10 @@ function processFilenameTemplate(result, options, filenameTemplate) {
       filename: result.filename,
     });
 
+    result.filename = result.filename
+      .replace(/\[width\]/gi, result.info.width)
+      .replace(/\[height\]/gi, result.info.height);
+
     // @ts-ignore
     result.info[isFilenameProcessed] = true;
   }

--- a/test/loader-generator-option.test.js
+++ b/test/loader-generator-option.test.js
@@ -254,9 +254,6 @@ describe("loader generator option", () => {
                 width: 100,
                 height: 50,
               },
-              rotate: {
-                numRotations: 90,
-              },
               encodeOptions: {
                 webp: {
                   lossless: true,
@@ -275,6 +272,162 @@ describe("loader generator option", () => {
       __dirname,
       compilation.options.output.path,
       "./nested/deep/loader-test.webp"
+    );
+
+    const transformedExt = await fileType.fromFile(transformedAsset);
+    const sizeOf = promisify(imageSize);
+    const dimensions = await sizeOf(transformedAsset);
+
+    expect(dimensions.height).toBe(50);
+    expect(dimensions.width).toBe(100);
+    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(warnings).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should minify and rename (sharpMinify)", async () => {
+    const stats = await runWebpack({
+      entry: path.join(fixturesPath, "./simple.js"),
+      imageminLoaderOptions: {
+        minimizer: {
+          implementation: ImageMinimizerPlugin.sharpMinify,
+          filename: "sharp-minify-[name]-[width]x[height][ext]",
+          options: {
+            encodeOptions: {
+              jpeg: { quality: 90 },
+            },
+          },
+        },
+      },
+    });
+
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+
+    const transformedAsset = path.resolve(
+      __dirname,
+      compilation.options.output.path,
+      "./sharp-minify-loader-test-1x1.jpg"
+    );
+
+    const transformedExt = await fileType.fromFile(transformedAsset);
+
+    expect(/image\/jpeg/i.test(transformedExt.mime)).toBe(true);
+    expect(warnings).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should generate, resize and rename (sharpGenerate)", async () => {
+    const stats = await runWebpack({
+      entry: path.join(fixturesPath, "./generator.js"),
+      imageminLoaderOptions: {
+        generator: [
+          {
+            preset: "webp",
+            implementation: ImageMinimizerPlugin.sharpGenerate,
+            filename: "sharp-generate-[name]-[width]x[height][ext]",
+            options: {
+              resize: {
+                enabled: true,
+                width: 100,
+                height: 50,
+              },
+              encodeOptions: {
+                webp: {
+                  lossless: true,
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+
+    const transformedAsset = path.resolve(
+      __dirname,
+      compilation.options.output.path,
+      "./sharp-generate-loader-test-100x50.webp"
+    );
+
+    const transformedExt = await fileType.fromFile(transformedAsset);
+    const sizeOf = promisify(imageSize);
+    const dimensions = await sizeOf(transformedAsset);
+
+    expect(dimensions.height).toBe(50);
+    expect(dimensions.width).toBe(100);
+    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(warnings).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should minify and rename (squooshMinify)", async () => {
+    const stats = await runWebpack({
+      entry: path.join(fixturesPath, "./simple.js"),
+      imageminLoaderOptions: {
+        minimizer: {
+          implementation: ImageMinimizerPlugin.squooshMinify,
+          filename: "squoosh-minify-[name]-[width]x[height][ext]",
+          options: {
+            encodeOptions: {
+              jpeg: { quality: 90 },
+            },
+          },
+        },
+      },
+    });
+
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+
+    const transformedAsset = path.resolve(
+      __dirname,
+      compilation.options.output.path,
+      "./squoosh-minify-loader-test-1x1.jpg"
+    );
+
+    const transformedExt = await fileType.fromFile(transformedAsset);
+
+    expect(/image\/jpeg/i.test(transformedExt.mime)).toBe(true);
+    expect(warnings).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should generate, resize and rename (squooshGenerate)", async () => {
+    const stats = await runWebpack({
+      entry: path.join(fixturesPath, "./generator.js"),
+      imageminLoaderOptions: {
+        generator: [
+          {
+            preset: "webp",
+            implementation: ImageMinimizerPlugin.squooshGenerate,
+            filename: "squoosh-generate-[name]-[width]x[height][ext]",
+            options: {
+              resize: {
+                enabled: true,
+                width: 100,
+                height: 50,
+              },
+              encodeOptions: {
+                webp: {
+                  lossless: true,
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+
+    const transformedAsset = path.resolve(
+      __dirname,
+      compilation.options.output.path,
+      "./squoosh-generate-loader-test-100x50.webp"
     );
 
     const transformedExt = await fileType.fromFile(transformedAsset);


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
A useful feature in combination with the resize option. Allow to use `width` and `height` in filename (e.g: filename: "[name]-[width]x[height][ext]")
