### PR TITLE
chore: disable some broken tests

### DIFF
--- a/test/ImageminPlugin.test.js
+++ b/test/ImageminPlugin.test.js
@@ -2259,7 +2259,7 @@ describe("imagemin plugin", () => {
     );
   });
 
-  ifit(needsTestWin)("should work with mini-css-extract-plugin", async () => {
+  it("should work with mini-css-extract-plugin", async () => {
     const stats = await runWebpack({
       fileLoaderOff: true,
       assetResource: true,
@@ -2270,11 +2270,11 @@ describe("imagemin plugin", () => {
         generator: [
           {
             preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
+            implementation: ImageMinimizerPlugin.sharpGenerate,
             options: {
               encodeOptions: {
                 webp: {
-                  lossless: 1,
+                  lossless: true,
                 },
               },
             },
@@ -2282,13 +2282,13 @@ describe("imagemin plugin", () => {
         ],
         minimizer: [
           {
-            implementation: ImageMinimizerPlugin.squooshMinify,
+            implementation: ImageMinimizerPlugin.sharpMinify,
             options: {
               encodeOptions: {
-                mozjpeg: {
+                jpeg: {
                   quality: 40,
                 },
-                oxipng: {
+                png: {
                   quality: 40,
                 },
               },

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -357,6 +357,39 @@ function clearDirectory(dirPath) {
   fs.rmdirSync(dirPath);
 }
 
+/**
+ * @param {boolean | () => boolean} predicate
+ * @returns {import("@jest/globals").it | import("@jest/globals").xit}
+ */
+function ifit(predicate) {
+  const cond = typeof predicate === "function" ? predicate() : predicate;
+
+  return cond ? it : xit;
+}
+
+/**
+ * @returns {boolean}
+ */
+function needsTestWin() {
+  const { platform } = process;
+  const nodeMajorVer = Number(process.version.slice(1).split(".")[0]);
+
+  // Disable tests for Windows and Nodejs > 14
+  // see: https://github.com/webpack-contrib/image-minimizer-webpack-plugin/pull/345
+  return !(platform === "win32" && nodeMajorVer > 14);
+}
+
+/**
+ * @returns {boolean}
+ */
+function needsTestAll() {
+  const nodeMajorVer = Number(process.version.slice(1).split(".")[0]);
+
+  // Disable tests for all and Nodejs > 16
+  // see: https://github.com/webpack-contrib/image-minimizer-webpack-plugin/pull/345
+  return !(nodeMajorVer > 16);
+}
+
 export default class EmitNewAssetPlugin {
   constructor(options = {}) {
     this.options = options;
@@ -397,4 +430,7 @@ export {
   normalizePath,
   clearDirectory,
   EmitNewAssetPlugin,
+  ifit,
+  needsTestAll,
+  needsTestWin,
 };

--- a/test/loader-generator-option.test.js
+++ b/test/loader-generator-option.test.js
@@ -1,15 +1,18 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/require-hook */
+
 import path from "path";
 import { promisify } from "util";
 import fileType from "file-type";
 import imageSize from "image-size";
 import ImageMinimizerPlugin from "../src";
 
-import { runWebpack, fixturesPath } from "./helpers";
+import { runWebpack, fixturesPath, ifit, needsTestAll } from "./helpers";
 
 jest.setTimeout(10000);
 
 describe("loader generator option", () => {
-  it("should work", async () => {
+  ifit(needsTestAll)("should work", async () => {
     const stats = await runWebpack({
       entry: path.join(fixturesPath, "./loader-single.js"),
       imageminLoaderOptions: {
@@ -116,129 +119,138 @@ describe("loader generator option", () => {
     );
   });
 
-  it("should generate the new webp image with other name using old loader approach", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "./loader-single.js"),
-      name: "foo-[name].[ext]",
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            options: {
-              encodeOptions: {
-                webp: {
-                  lossless: 1,
+  ifit(needsTestAll)(
+    "should generate the new webp image with other name using old loader approach",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "./loader-single.js"),
+        name: "foo-[name].[ext]",
+        imageminLoaderOptions: {
+          generator: [
+            {
+              preset: "webp",
+              implementation: ImageMinimizerPlugin.squooshGenerate,
+              options: {
+                encodeOptions: {
+                  webp: {
+                    lossless: 1,
+                  },
                 },
               },
             },
-          },
-        ],
-      },
-    });
+          ],
+        },
+      });
 
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
+      const { compilation } = stats;
+      const { warnings, errors } = compilation;
 
-    const transformedAsset = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "foo-loader-test.webp"
-    );
+      const transformedAsset = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        "foo-loader-test.webp"
+      );
 
-    const transformedExt = await fileType.fromFile(transformedAsset);
+      const transformedExt = await fileType.fromFile(transformedAsset);
 
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-  });
+      expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    }
+  );
 
-  it("should generate the new webp image with other name using asset modules name", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "./loader-single.js"),
-      fileLoaderOff: true,
-      assetResource: true,
-      name: "foo-[name][ext]",
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            options: {
-              encodeOptions: {
-                webp: {
-                  lossless: 1,
+  ifit(needsTestAll)(
+    "should generate the new webp image with other name using asset modules name",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "./loader-single.js"),
+        fileLoaderOff: true,
+        assetResource: true,
+        name: "foo-[name][ext]",
+        imageminLoaderOptions: {
+          generator: [
+            {
+              preset: "webp",
+              implementation: ImageMinimizerPlugin.squooshGenerate,
+              options: {
+                encodeOptions: {
+                  webp: {
+                    lossless: 1,
+                  },
                 },
               },
             },
-          },
-        ],
-      },
-    });
+          ],
+        },
+      });
 
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
+      const { compilation } = stats;
+      const { warnings, errors } = compilation;
 
-    const transformedAsset = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "foo-loader-test.webp"
-    );
+      const transformedAsset = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        "foo-loader-test.webp"
+      );
 
-    const transformedExt = await fileType.fromFile(transformedAsset);
+      const transformedExt = await fileType.fromFile(transformedAsset);
 
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-  });
+      expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    }
+  );
 
-  it("should generate and resize (squooshGenerate)", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "./loader-single.js"),
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            options: {
-              resize: {
-                enabled: true,
-                width: 100,
-                height: 50,
-              },
-              rotate: {
-                numRotations: 90,
-              },
-              encodeOptions: {
-                webp: {
-                  lossless: 1,
+  ifit(needsTestAll)(
+    "should generate and resize (squooshGenerate)",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "./loader-single.js"),
+        imageminLoaderOptions: {
+          generator: [
+            {
+              preset: "webp",
+              implementation: ImageMinimizerPlugin.squooshGenerate,
+              options: {
+                resize: {
+                  enabled: true,
+                  width: 100,
+                  height: 50,
+                },
+                rotate: {
+                  numRotations: 90,
+                },
+                encodeOptions: {
+                  webp: {
+                    lossless: 1,
+                  },
                 },
               },
             },
-          },
-        ],
-      },
-    });
+          ],
+        },
+      });
 
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
+      const { compilation } = stats;
+      const { warnings, errors } = compilation;
 
-    const transformedAsset = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "./nested/deep/loader-test.webp"
-    );
+      const transformedAsset = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        "./nested/deep/loader-test.webp"
+      );
 
-    const transformedExt = await fileType.fromFile(transformedAsset);
-    const sizeOf = promisify(imageSize);
-    const dimensions = await sizeOf(transformedAsset);
+      const transformedExt = await fileType.fromFile(transformedAsset);
+      const sizeOf = promisify(imageSize);
+      const dimensions = await sizeOf(transformedAsset);
 
-    expect(dimensions.height).toBe(50);
-    expect(dimensions.width).toBe(100);
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-  });
+      expect(dimensions.height).toBe(50);
+      expect(dimensions.width).toBe(100);
+      expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    }
+  );
 
   it("should generate and resize (sharpGenerate)", async () => {
     const stats = await runWebpack({
@@ -363,7 +375,7 @@ describe("loader generator option", () => {
     expect(errors).toHaveLength(0);
   });
 
-  it("should minify and rename (squooshMinify)", async () => {
+  ifit(needsTestAll)("should minify and rename (squooshMinify)", async () => {
     const stats = await runWebpack({
       entry: path.join(fixturesPath, "./simple.js"),
       imageminLoaderOptions: {
@@ -395,49 +407,52 @@ describe("loader generator option", () => {
     expect(errors).toHaveLength(0);
   });
 
-  it("should generate, resize and rename (squooshGenerate)", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "./generator.js"),
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            filename: "squoosh-generate-[name]-[width]x[height][ext]",
-            options: {
-              resize: {
-                enabled: true,
-                width: 100,
-                height: 50,
-              },
-              encodeOptions: {
-                webp: {
-                  lossless: true,
+  ifit(needsTestAll)(
+    "should generate, resize and rename (squooshGenerate)",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "./generator.js"),
+        imageminLoaderOptions: {
+          generator: [
+            {
+              preset: "webp",
+              implementation: ImageMinimizerPlugin.squooshGenerate,
+              filename: "squoosh-generate-[name]-[width]x[height][ext]",
+              options: {
+                resize: {
+                  enabled: true,
+                  width: 100,
+                  height: 50,
+                },
+                encodeOptions: {
+                  webp: {
+                    lossless: true,
+                  },
                 },
               },
             },
-          },
-        ],
-      },
-    });
+          ],
+        },
+      });
 
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
+      const { compilation } = stats;
+      const { warnings, errors } = compilation;
 
-    const transformedAsset = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "./squoosh-generate-loader-test-100x50.webp"
-    );
+      const transformedAsset = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        "./squoosh-generate-loader-test-100x50.webp"
+      );
 
-    const transformedExt = await fileType.fromFile(transformedAsset);
-    const sizeOf = promisify(imageSize);
-    const dimensions = await sizeOf(transformedAsset);
+      const transformedExt = await fileType.fromFile(transformedAsset);
+      const sizeOf = promisify(imageSize);
+      const dimensions = await sizeOf(transformedAsset);
 
-    expect(dimensions.height).toBe(50);
-    expect(dimensions.width).toBe(100);
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-  });
+      expect(dimensions.height).toBe(50);
+      expect(dimensions.width).toBe(100);
+      expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    }
+  );
 });

--- a/test/loader-minimizer-option.test.js
+++ b/test/loader-minimizer-option.test.js
@@ -1,10 +1,19 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/require-hook */
+
 import { promisify } from "util";
 import path from "path";
 import imageSize from "image-size";
 
 import ImageMinimizerPlugin from "../src";
 
-import { runWebpack, isOptimized, plugins } from "./helpers";
+import {
+  runWebpack,
+  isOptimized,
+  plugins,
+  ifit,
+  needsTestAll,
+} from "./helpers";
 
 describe("loader minimizer option", () => {
   it("should work with object notation of the 'minifier' option", async () => {
@@ -265,7 +274,7 @@ describe("loader minimizer option", () => {
     );
   });
 
-  it('should work with "squooshMinify" minifier', async () => {
+  ifit(needsTestAll)('should work with "squooshMinify" minifier', async () => {
     const stats = await runWebpack({
       imageminLoader: true,
       imageminLoaderOptions: {
@@ -434,44 +443,49 @@ describe("loader minimizer option", () => {
     );
   });
 
-  it('should minimize and resize with "squooshMinify" minifier', async () => {
-    const stats = await runWebpack({
-      imageminLoader: true,
-      imageminLoaderOptions: {
-        minimizer: {
-          implementation: ImageMinimizerPlugin.squooshMinify,
-          options: {
-            resize: {
-              enabled: true,
-              width: 100,
-              height: 50,
-            },
-            rotate: {
-              numRotations: 90,
+  ifit(needsTestAll)(
+    'should minimize and resize with "squooshMinify" minifier',
+    async () => {
+      const stats = await runWebpack({
+        imageminLoader: true,
+        imageminLoaderOptions: {
+          minimizer: {
+            implementation: ImageMinimizerPlugin.squooshMinify,
+            options: {
+              resize: {
+                enabled: true,
+                width: 100,
+                height: 50,
+              },
+              rotate: {
+                numRotations: 90,
+              },
             },
           },
         },
-      },
-    });
-    const { compilation } = stats;
-    const { errors } = compilation;
+      });
+      const { compilation } = stats;
+      const { errors } = compilation;
 
-    const sizeOf = promisify(imageSize);
-    const transformedAsset = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "./loader-test.png"
-    );
-    const dimensions = await sizeOf(transformedAsset);
+      const sizeOf = promisify(imageSize);
+      const transformedAsset = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        "./loader-test.png"
+      );
+      const dimensions = await sizeOf(transformedAsset);
 
-    expect(dimensions.height).toBe(50);
-    expect(dimensions.width).toBe(100);
-    expect(errors).toHaveLength(0);
-    expect(compilation.getAsset("loader-test.jpg").info.size).toBeLessThan(631);
-    expect(compilation.getAsset("loader-test.png").info.size).toBeLessThan(
-      71000
-    );
-  });
+      expect(dimensions.height).toBe(50);
+      expect(dimensions.width).toBe(100);
+      expect(errors).toHaveLength(0);
+      expect(compilation.getAsset("loader-test.jpg").info.size).toBeLessThan(
+        631
+      );
+      expect(compilation.getAsset("loader-test.png").info.size).toBeLessThan(
+        71000
+      );
+    }
+  );
 
   it('should minimize and resize with "sharpMinify" minifier', async () => {
     const stats = await runWebpack({

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,10 +1,20 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/require-hook */
+
 import fs from "fs";
 import path from "path";
 
 import pify from "pify";
 import fileType from "file-type";
 
-import { fixturesPath, isOptimized, plugins, runWebpack } from "./helpers";
+import {
+  fixturesPath,
+  isOptimized,
+  plugins,
+  runWebpack,
+  ifit,
+  needsTestAll,
+} from "./helpers";
 import ImageMinimizerPlugin from "../src/index.js";
 
 jest.setTimeout(20000);
@@ -139,81 +149,16 @@ describe("loader", () => {
     );
   });
 
-  it("should optimizes all images and don't break non images ('squooshMinify')", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "loader-other-imports.js"),
-      test: /\.(jpe?g|png|gif|svg|css|txt)$/i,
-      imageminLoaderOptions: {
-        minimizer: {
-          implementation: ImageMinimizerPlugin.squooshMinify,
-          options: {
-            mozjpeg: {
-              quality: 40,
-            },
-            oxipng: {
-              quality: 40,
-            },
-          },
-        },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors, assets } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-    expect(Object.keys(assets)).toHaveLength(7);
-
-    const txtBuffer = await pify(fs.readFile)(
-      path.join(compilation.options.output.path, "loader-test.txt")
-    );
-
-    expect(txtBuffer.toString().replace(/\r\n|\r/g, "\n")).toBe("TEXT\n");
-
-    const cssBuffer = await pify(fs.readFile)(
-      path.join(compilation.options.output.path, "loader-test.css")
-    );
-
-    expect(cssBuffer.toString().replace(/\r\n|\r/g, "\n")).toBe(
-      "a {\n  color: red;\n}\n"
-    );
-
-    await expect(isOptimized("loader-test.gif", compilation)).resolves.toBe(
-      false
-    );
-    await expect(isOptimized("loader-test.jpg", compilation)).resolves.toBe(
-      false
-    );
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      false
-    );
-    await expect(isOptimized("loader-test.svg", compilation)).resolves.toBe(
-      false
-    );
-  });
-
-  it("should generate all images and don't break non images ('squooshGenerate')", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "loader-other-imports-1.js"),
-      test: /\.(jpe?g|png|gif|svg|css|txt)$/i,
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
+  ifit(needsTestAll)(
+    "should optimizes all images and don't break non images ('squooshMinify')",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "loader-other-imports.js"),
+        test: /\.(jpe?g|png|gif|svg|css|txt)$/i,
+        imageminLoaderOptions: {
+          minimizer: {
+            implementation: ImageMinimizerPlugin.squooshMinify,
             options: {
-              encodeOptions: {
-                webp: {
-                  quality: 90,
-                },
-              },
-            },
-          },
-        ],
-        minimizer: {
-          implementation: ImageMinimizerPlugin.squooshMinify,
-          options: {
-            encodeOptions: {
               mozjpeg: {
                 quality: 40,
               },
@@ -223,43 +168,114 @@ describe("loader", () => {
             },
           },
         },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors, assets } = compilation;
+      });
+      const { compilation } = stats;
+      const { warnings, errors, assets } = compilation;
 
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-    expect(Object.keys(assets)).toHaveLength(8);
-    expect(Object.keys(assets)).toContain("loader-test.webp");
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+      expect(Object.keys(assets)).toHaveLength(7);
 
-    const txtBuffer = await pify(fs.readFile)(
-      path.join(compilation.options.output.path, "loader-test.txt")
-    );
+      const txtBuffer = await pify(fs.readFile)(
+        path.join(compilation.options.output.path, "loader-test.txt")
+      );
 
-    expect(txtBuffer.toString().replace(/\r\n|\r/g, "\n")).toBe("TEXT\n");
+      expect(txtBuffer.toString().replace(/\r\n|\r/g, "\n")).toBe("TEXT\n");
 
-    const cssBuffer = await pify(fs.readFile)(
-      path.join(compilation.options.output.path, "loader-test.css")
-    );
+      const cssBuffer = await pify(fs.readFile)(
+        path.join(compilation.options.output.path, "loader-test.css")
+      );
 
-    expect(cssBuffer.toString().replace(/\r\n|\r/g, "\n")).toBe(
-      "a {\n  color: red;\n}\n"
-    );
+      expect(cssBuffer.toString().replace(/\r\n|\r/g, "\n")).toBe(
+        "a {\n  color: red;\n}\n"
+      );
 
-    await expect(isOptimized("loader-test.gif", compilation)).resolves.toBe(
-      false
-    );
-    await expect(isOptimized("loader-test.jpg", compilation)).resolves.toBe(
-      false
-    );
-    await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
-      false
-    );
-    await expect(isOptimized("loader-test.svg", compilation)).resolves.toBe(
-      false
-    );
-  });
+      await expect(isOptimized("loader-test.gif", compilation)).resolves.toBe(
+        false
+      );
+      await expect(isOptimized("loader-test.jpg", compilation)).resolves.toBe(
+        false
+      );
+      await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
+        false
+      );
+      await expect(isOptimized("loader-test.svg", compilation)).resolves.toBe(
+        false
+      );
+    }
+  );
+
+  ifit(needsTestAll)(
+    "should generate all images and don't break non images ('squooshGenerate')",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "loader-other-imports-1.js"),
+        test: /\.(jpe?g|png|gif|svg|css|txt)$/i,
+        imageminLoaderOptions: {
+          generator: [
+            {
+              preset: "webp",
+              implementation: ImageMinimizerPlugin.squooshGenerate,
+              options: {
+                encodeOptions: {
+                  webp: {
+                    quality: 90,
+                  },
+                },
+              },
+            },
+          ],
+          minimizer: {
+            implementation: ImageMinimizerPlugin.squooshMinify,
+            options: {
+              encodeOptions: {
+                mozjpeg: {
+                  quality: 40,
+                },
+                oxipng: {
+                  quality: 40,
+                },
+              },
+            },
+          },
+        },
+      });
+      const { compilation } = stats;
+      const { warnings, errors, assets } = compilation;
+
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+      expect(Object.keys(assets)).toHaveLength(8);
+      expect(Object.keys(assets)).toContain("loader-test.webp");
+
+      const txtBuffer = await pify(fs.readFile)(
+        path.join(compilation.options.output.path, "loader-test.txt")
+      );
+
+      expect(txtBuffer.toString().replace(/\r\n|\r/g, "\n")).toBe("TEXT\n");
+
+      const cssBuffer = await pify(fs.readFile)(
+        path.join(compilation.options.output.path, "loader-test.css")
+      );
+
+      expect(cssBuffer.toString().replace(/\r\n|\r/g, "\n")).toBe(
+        "a {\n  color: red;\n}\n"
+      );
+
+      await expect(isOptimized("loader-test.gif", compilation)).resolves.toBe(
+        false
+      );
+      await expect(isOptimized("loader-test.jpg", compilation)).resolves.toBe(
+        false
+      );
+      await expect(isOptimized("loader-test.png", compilation)).resolves.toBe(
+        false
+      );
+      await expect(isOptimized("loader-test.svg", compilation)).resolves.toBe(
+        false
+      );
+    }
+  );
 
   it("should optimizes all images and don't break non images ('sharpMinify')", async () => {
     const stats = await runWebpack({
@@ -409,76 +425,82 @@ describe("loader", () => {
     expect(/image\/webp/i.test(ext.mime)).toBe(true);
   });
 
-  it("should generate and minimize images (imageminGenerate) using absolute URLs", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "generator-asset-modules.js"),
-      fileLoaderOff: true,
-      assetResource: true,
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            options: {
-              encodeOptions: {
-                webp: {},
-              },
-            },
-          },
-        ],
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-
-    const file = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "./loader-test.webp"
-    );
-    const ext = await fileType.fromFile(file);
-
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
-  });
-
-  it("should optimizes and generate images (squooshGenerate)", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "generator.js"),
-      imageminLoader: true,
-      imageminLoaderOptions: {
-        generator: [
-          {
-            preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
-            options: {
-              encodeOptions: {
-                webp: {
-                  lossless: 1,
+  ifit(needsTestAll)(
+    "should generate and minimize images (imageminGenerate) using absolute URLs",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "generator-asset-modules.js"),
+        fileLoaderOff: true,
+        assetResource: true,
+        imageminLoaderOptions: {
+          generator: [
+            {
+              preset: "webp",
+              implementation: ImageMinimizerPlugin.squooshGenerate,
+              options: {
+                encodeOptions: {
+                  webp: {},
                 },
               },
             },
-          },
-        ],
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
+          ],
+        },
+      });
+      const { compilation } = stats;
+      const { warnings, errors } = compilation;
 
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
 
-    const file = path.resolve(
-      __dirname,
-      compilation.options.output.path,
-      "loader-test.webp"
-    );
-    const ext = await fileType.fromFile(file);
+      const file = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        "./loader-test.webp"
+      );
+      const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
-  });
+      expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    }
+  );
+
+  ifit(needsTestAll)(
+    "should optimizes and generate images (squooshGenerate)",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "generator.js"),
+        imageminLoader: true,
+        imageminLoaderOptions: {
+          generator: [
+            {
+              preset: "webp",
+              implementation: ImageMinimizerPlugin.squooshGenerate,
+              options: {
+                encodeOptions: {
+                  webp: {
+                    lossless: 1,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      });
+      const { compilation } = stats;
+      const { warnings, errors } = compilation;
+
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+
+      const file = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        "loader-test.webp"
+      );
+      const ext = await fileType.fromFile(file);
+
+      expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    }
+  );
 
   it("should optimizes and generate images (sharpGenerate)", async () => {
     const stats = await runWebpack({

--- a/test/plugin-minimizer-option.test.js
+++ b/test/plugin-minimizer-option.test.js
@@ -1,3 +1,6 @@
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable jest/require-hook */
+
 import path from "path";
 
 import fileType from "file-type";
@@ -9,6 +12,8 @@ import {
   isOptimized,
   plugins,
   hasLoader,
+  ifit,
+  needsTestAll,
 } from "./helpers";
 
 jest.setTimeout(10000);
@@ -38,7 +43,7 @@ describe("plugin minify option", () => {
     expect(errors).toHaveLength(0);
   });
 
-  it('should work with "squooshMinify" minifier', async () => {
+  ifit(needsTestAll)('should work with "squooshMinify" minifier', async () => {
     const stats = await runWebpack({
       entry: path.join(fixturesPath, "./empty-entry.js"),
       emitPlugin: true,
@@ -217,36 +222,41 @@ describe("plugin minify option", () => {
     expect(errors).toHaveLength(0);
   });
 
-  it("should work with 'squooshMinify' minifier and 'minimizerOptions'", async () => {
-    const stats = await runWebpack({
-      entry: path.join(fixturesPath, "./empty-entry.js"),
-      emitPlugin: true,
-      imageminPluginOptions: {
-        minimizer: {
-          implementation: ImageMinimizerPlugin.squooshMinify,
-          options: {
-            encodeOptions: {
-              mozjpeg: {
-                quality: 75,
-              },
-              webp: {
-                lossless: 1,
-              },
-              avif: {
-                cqLevel: 0,
+  ifit(needsTestAll)(
+    "should work with 'squooshMinify' minifier and 'minimizerOptions'",
+    async () => {
+      const stats = await runWebpack({
+        entry: path.join(fixturesPath, "./empty-entry.js"),
+        emitPlugin: true,
+        imageminPluginOptions: {
+          minimizer: {
+            implementation: ImageMinimizerPlugin.squooshMinify,
+            options: {
+              encodeOptions: {
+                mozjpeg: {
+                  quality: 75,
+                },
+                webp: {
+                  lossless: 1,
+                },
+                avif: {
+                  cqLevel: 0,
+                },
               },
             },
           },
         },
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
+      });
+      const { compilation } = stats;
+      const { warnings, errors } = compilation;
 
-    expect(compilation.getAsset("plugin-test.jpg").info.size).toBeLessThan(335);
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-  });
+      expect(compilation.getAsset("plugin-test.jpg").info.size).toBeLessThan(
+        335
+      );
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    }
+  );
 
   it("should optimizes all images (loader + plugin) exclude filtered", async () => {
     const stats = await runWebpack({


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Because `squooshLib` is broken on Windows and some Node versions:
- disable some tests for Windows and Nodejs > 14
- disable some tests for all and Nodejs > 16