### PR TITLE
feat: add size query parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,16 @@ const {
 
 /**
  * @template T
- * @typedef {InferDefaultType<T> | undefined} BasicTransformerOptions
+ * @typedef {Object} BasicTransformerOptions
+ * @property {ResizeOptions} [resize]
+ * @property {InferDefaultType<T>} [encodeOptions]
+ */
+
+/**
+ * @typedef {Object} ResizeOptions
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {boolean} [enabled]
  */
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -79,9 +79,7 @@ const {
 
 /**
  * @template T
- * @typedef {Object} BasicTransformerOptions
- * @property {ResizeOptions} [resize]
- * @property {InferDefaultType<T>} [encodeOptions]
+ * @typedef {InferDefaultType<T> | undefined} BasicTransformerOptions
  */
 
 /**

--- a/src/loader.js
+++ b/src/loader.js
@@ -50,31 +50,32 @@ function processSizeQuery(transformers, widthQuery, heightQuery) {
   return transformers.map((transformer) => {
     const minimizer = { ...transformer };
 
-    const resizeOptions = { ...minimizer.options?.resize };
+    const minimizerOptions =
+      /** @type { import("./index").BasicTransformerOptions<T> & { resize?: import("./index").ResizeOptions }} */
+      // @ts-ignore
+      ({ ...minimizer.options });
+
+    minimizerOptions.resize = { ...minimizerOptions?.resize };
+    minimizer.options = minimizerOptions;
 
     if (widthQuery === "auto") {
-      delete resizeOptions.width;
+      delete minimizerOptions.resize.width;
     } else if (widthQuery) {
       const width = Number.parseInt(widthQuery, 10);
 
       if (Number.isFinite(width) && width > 0) {
-        resizeOptions.width = width;
+        minimizerOptions.resize.width = width;
       }
     }
 
     if (heightQuery === "auto") {
-      delete resizeOptions.height;
+      delete minimizerOptions.resize.height;
     } else if (heightQuery) {
       const height = Number.parseInt(heightQuery, 10);
 
       if (Number.isFinite(height) && height > 0) {
-        resizeOptions.height = height;
+        minimizerOptions.resize.height = height;
       }
-    }
-
-    if (resizeOptions.width || resizeOptions.height) {
-      minimizer.options = { ...minimizer.options };
-      minimizer.options.resize = resizeOptions;
     }
 
     return minimizer;

--- a/src/utils.js
+++ b/src/utils.js
@@ -799,6 +799,7 @@ async function squooshGenerate(original, minifyOptions) {
 
   const { binary, extension } = await Object.values(image.encodedWith)[0];
   const { width, height } = (await image.decoded).bitmap;
+
   const { dir: fileDir, name: fileName } = path.parse(original.filename);
   const filename = path.join(fileDir, `${fileName}.${extension}`);
 

--- a/test/fixtures/generator-and-minimizer-resize-query.js
+++ b/test/fixtures/generator-and-minimizer-resize-query.js
@@ -1,0 +1,13 @@
+require("./loader-test.png?width=100");
+require("./loader-test.png?w=150");
+require("./loader-test.png?height=200");
+require("./loader-test.png?h=250");
+require("./loader-test.png?width=300&height=auto");
+require("./loader-test.png?width=350&height=350");
+
+require("./loader-test.png?as=webp&width=100");
+require("./loader-test.png?as=webp&w=150");
+require("./loader-test.png?as=webp&height=200");
+require("./loader-test.png?as=webp&h=250");
+require("./loader-test.png?as=webp&width=300&height=auto");
+require("./loader-test.png?as=webp&width=350&height=350");

--- a/test/fixtures/generator-and-minimizer-resize-query.js
+++ b/test/fixtures/generator-and-minimizer-resize-query.js
@@ -3,6 +3,7 @@ require("./loader-test.png?w=150");
 require("./loader-test.png?height=200");
 require("./loader-test.png?h=250");
 require("./loader-test.png?width=300&height=auto");
+require("./loader-test.png?width=auto&height=320");
 require("./loader-test.png?width=350&height=350");
 
 require("./loader-test.png?as=webp&width=100");
@@ -10,4 +11,5 @@ require("./loader-test.png?as=webp&w=150");
 require("./loader-test.png?as=webp&height=200");
 require("./loader-test.png?as=webp&h=250");
 require("./loader-test.png?as=webp&width=300&height=auto");
+require("./loader-test.png?as=webp&width=auto&height=320");
 require("./loader-test.png?as=webp&width=350&height=350");

--- a/test/resize-query.test.js
+++ b/test/resize-query.test.js
@@ -1,0 +1,163 @@
+import path from "path";
+import { promisify } from "util";
+import fileType from "file-type";
+import imageSize from "image-size";
+import ImageMinimizerPlugin from "../src";
+
+import { runWebpack, fixturesPath } from "./helpers";
+
+jest.setTimeout(20000);
+
+describe("resize query", () => {
+  it("should generate and resize with resize options", async () => {
+    const stats = await runWebpack({
+      entry: path.join(
+        fixturesPath,
+        "./generator-and-minimizer-resize-query.js"
+      ),
+      imageminLoaderOptions: {
+        minimizer: {
+          implementation: ImageMinimizerPlugin.squooshMinify,
+          filename: "[name]-[width]x[height][ext]",
+          options: {
+            resize: {
+              width: 400,
+              height: 400,
+            },
+            encodeOptions: {
+              png: {},
+            },
+          },
+        },
+        generator: [
+          {
+            preset: "webp",
+            implementation: ImageMinimizerPlugin.squooshGenerate,
+            filename: "[name]-[width]x[height][ext]",
+            options: {
+              resize: {
+                width: 400,
+                height: 400,
+              },
+              encodeOptions: {
+                webp: {},
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+    const sizeOf = promisify(imageSize);
+
+    const assetsList = [
+      // asset path, width, height, mime regExp
+      ["./loader-test-100x400.png", 100, 400, /image\/png/i],
+      ["./loader-test-150x400.png", 150, 400, /image\/png/i],
+      ["./loader-test-400x200.png", 400, 200, /image\/png/i],
+      ["./loader-test-400x250.png", 400, 250, /image\/png/i],
+      ["./loader-test-300x300.png", 300, 300, /image\/png/i],
+      ["./loader-test-350x350.png", 350, 350, /image\/png/i],
+
+      ["./loader-test-100x400.webp", 100, 400, /image\/webp/i],
+      ["./loader-test-150x400.webp", 150, 400, /image\/webp/i],
+      ["./loader-test-400x200.webp", 400, 200, /image\/webp/i],
+      ["./loader-test-400x250.webp", 400, 250, /image\/webp/i],
+      ["./loader-test-300x300.webp", 300, 300, /image\/webp/i],
+      ["./loader-test-350x350.webp", 350, 350, /image\/webp/i],
+    ];
+
+    for (const [assetPath, width, height, mimeRegExp] of assetsList) {
+      const transformedAsset = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        assetPath
+      );
+
+      // eslint-disable-next-line no-await-in-loop
+      const transformedExt = await fileType.fromFile(transformedAsset);
+      // eslint-disable-next-line no-await-in-loop
+      const dimensions = await sizeOf(transformedAsset);
+
+      expect(dimensions.width).toBe(width);
+      expect(dimensions.height).toBe(height);
+      expect(mimeRegExp.test(transformedExt.mime)).toBe(true);
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it("should generate and resize without resize options", async () => {
+    const stats = await runWebpack({
+      entry: path.join(
+        fixturesPath,
+        "./generator-and-minimizer-resize-query.js"
+      ),
+      imageminLoaderOptions: {
+        minimizer: {
+          implementation: ImageMinimizerPlugin.squooshMinify,
+          filename: "[name]-[width]x[height][ext]",
+          options: {
+            encodeOptions: {
+              png: {},
+            },
+          },
+        },
+        generator: [
+          {
+            preset: "webp",
+            implementation: ImageMinimizerPlugin.squooshGenerate,
+            filename: "[name]-[width]x[height][ext]",
+            options: {
+              encodeOptions: {
+                webp: {},
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+    const sizeOf = promisify(imageSize);
+
+    const assetsList = [
+      // asset path, width, height, mime regExp
+      ["./loader-test-100x100.png", 100, 100, /image\/png/i],
+      ["./loader-test-150x150.png", 150, 150, /image\/png/i],
+      ["./loader-test-200x200.png", 200, 200, /image\/png/i],
+      ["./loader-test-250x250.png", 250, 250, /image\/png/i],
+      ["./loader-test-300x300.png", 300, 300, /image\/png/i],
+      ["./loader-test-350x350.png", 350, 350, /image\/png/i],
+
+      ["./loader-test-100x100.webp", 100, 100, /image\/webp/i],
+      ["./loader-test-150x150.webp", 150, 150, /image\/webp/i],
+      ["./loader-test-200x200.webp", 200, 200, /image\/webp/i],
+      ["./loader-test-250x250.webp", 250, 250, /image\/webp/i],
+      ["./loader-test-300x300.webp", 300, 300, /image\/webp/i],
+      ["./loader-test-350x350.webp", 350, 350, /image\/webp/i],
+    ];
+
+    for (const [assetPath, width, height, mimeRegExp] of assetsList) {
+      const transformedAsset = path.resolve(
+        __dirname,
+        compilation.options.output.path,
+        assetPath
+      );
+
+      // eslint-disable-next-line no-await-in-loop
+      const transformedExt = await fileType.fromFile(transformedAsset);
+      // eslint-disable-next-line no-await-in-loop
+      const dimensions = await sizeOf(transformedAsset);
+
+      expect(dimensions.width).toBe(width);
+      expect(dimensions.height).toBe(height);
+      expect(mimeRegExp.test(transformedExt.mime)).toBe(true);
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    }
+  });
+});

--- a/test/resize-query.test.js
+++ b/test/resize-query.test.js
@@ -17,7 +17,7 @@ describe("resize query", () => {
       ),
       imageminLoaderOptions: {
         minimizer: {
-          implementation: ImageMinimizerPlugin.sharpMinify,
+          implementation: ImageMinimizerPlugin.squooshMinify,
           filename: "[name]-[width]x[height][ext]",
           options: {
             resize: {
@@ -32,7 +32,7 @@ describe("resize query", () => {
         generator: [
           {
             preset: "webp",
-            implementation: ImageMinimizerPlugin.sharpGenerate,
+            implementation: ImageMinimizerPlugin.squooshGenerate,
             filename: "[name]-[width]x[height][ext]",
             options: {
               resize: {
@@ -59,6 +59,7 @@ describe("resize query", () => {
       ["./loader-test-400x200.png", 400, 200, /image\/png/i],
       ["./loader-test-400x250.png", 400, 250, /image\/png/i],
       ["./loader-test-300x300.png", 300, 300, /image\/png/i],
+      ["./loader-test-320x320.png", 320, 320, /image\/png/i],
       ["./loader-test-350x350.png", 350, 350, /image\/png/i],
 
       ["./loader-test-100x400.webp", 100, 400, /image\/webp/i],
@@ -66,6 +67,7 @@ describe("resize query", () => {
       ["./loader-test-400x200.webp", 400, 200, /image\/webp/i],
       ["./loader-test-400x250.webp", 400, 250, /image\/webp/i],
       ["./loader-test-300x300.webp", 300, 300, /image\/webp/i],
+      ["./loader-test-320x320.webp", 320, 320, /image\/webp/i],
       ["./loader-test-350x350.webp", 350, 350, /image\/webp/i],
     ];
 
@@ -97,7 +99,7 @@ describe("resize query", () => {
       ),
       imageminLoaderOptions: {
         minimizer: {
-          implementation: ImageMinimizerPlugin.sharpMinify,
+          implementation: ImageMinimizerPlugin.squooshMinify,
           filename: "[name]-[width]x[height][ext]",
           options: {
             encodeOptions: {
@@ -108,7 +110,7 @@ describe("resize query", () => {
         generator: [
           {
             preset: "webp",
-            implementation: ImageMinimizerPlugin.sharpGenerate,
+            implementation: ImageMinimizerPlugin.squooshGenerate,
             filename: "[name]-[width]x[height][ext]",
             options: {
               encodeOptions: {
@@ -131,6 +133,7 @@ describe("resize query", () => {
       ["./loader-test-200x200.png", 200, 200, /image\/png/i],
       ["./loader-test-250x250.png", 250, 250, /image\/png/i],
       ["./loader-test-300x300.png", 300, 300, /image\/png/i],
+      ["./loader-test-320x320.png", 320, 320, /image\/png/i],
       ["./loader-test-350x350.png", 350, 350, /image\/png/i],
 
       ["./loader-test-100x100.webp", 100, 100, /image\/webp/i],
@@ -138,6 +141,7 @@ describe("resize query", () => {
       ["./loader-test-200x200.webp", 200, 200, /image\/webp/i],
       ["./loader-test-250x250.webp", 250, 250, /image\/webp/i],
       ["./loader-test-300x300.webp", 300, 300, /image\/webp/i],
+      ["./loader-test-320x320.webp", 320, 320, /image\/webp/i],
       ["./loader-test-350x350.webp", 350, 350, /image\/webp/i],
     ];
 

--- a/test/resize-query.test.js
+++ b/test/resize-query.test.js
@@ -17,7 +17,7 @@ describe("resize query", () => {
       ),
       imageminLoaderOptions: {
         minimizer: {
-          implementation: ImageMinimizerPlugin.squooshMinify,
+          implementation: ImageMinimizerPlugin.sharpMinify,
           filename: "[name]-[width]x[height][ext]",
           options: {
             resize: {
@@ -32,7 +32,7 @@ describe("resize query", () => {
         generator: [
           {
             preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
+            implementation: ImageMinimizerPlugin.sharpGenerate,
             filename: "[name]-[width]x[height][ext]",
             options: {
               resize: {
@@ -97,7 +97,7 @@ describe("resize query", () => {
       ),
       imageminLoaderOptions: {
         minimizer: {
-          implementation: ImageMinimizerPlugin.squooshMinify,
+          implementation: ImageMinimizerPlugin.sharpMinify,
           filename: "[name]-[width]x[height][ext]",
           options: {
             encodeOptions: {
@@ -108,7 +108,7 @@ describe("resize query", () => {
         generator: [
           {
             preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
+            implementation: ImageMinimizerPlugin.sharpGenerate,
             filename: "[name]-[width]x[height][ext]",
             options: {
               encodeOptions: {

--- a/test/resize-query.test.js
+++ b/test/resize-query.test.js
@@ -17,7 +17,7 @@ describe("resize query", () => {
       ),
       imageminLoaderOptions: {
         minimizer: {
-          implementation: ImageMinimizerPlugin.squooshMinify,
+          implementation: ImageMinimizerPlugin.sharpMinify,
           filename: "[name]-[width]x[height][ext]",
           options: {
             resize: {
@@ -32,7 +32,7 @@ describe("resize query", () => {
         generator: [
           {
             preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
+            implementation: ImageMinimizerPlugin.sharpGenerate,
             filename: "[name]-[width]x[height][ext]",
             options: {
               resize: {
@@ -99,7 +99,7 @@ describe("resize query", () => {
       ),
       imageminLoaderOptions: {
         minimizer: {
-          implementation: ImageMinimizerPlugin.squooshMinify,
+          implementation: ImageMinimizerPlugin.sharpMinify,
           filename: "[name]-[width]x[height][ext]",
           options: {
             encodeOptions: {
@@ -110,7 +110,7 @@ describe("resize query", () => {
         generator: [
           {
             preset: "webp",
-            implementation: ImageMinimizerPlugin.squooshGenerate,
+            implementation: ImageMinimizerPlugin.sharpGenerate,
             filename: "[name]-[width]x[height][ext]",
             options: {
               encodeOptions: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,15 @@ export = ImageMinimizerPlugin;
  */
 /**
  * @template T
- * @typedef {InferDefaultType<T> | undefined} BasicTransformerOptions
+ * @typedef {Object} BasicTransformerOptions
+ * @property {ResizeOptions} [resize]
+ * @property {InferDefaultType<T>} [encodeOptions]
+ */
+/**
+ * @typedef {Object} ResizeOptions
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {boolean} [enabled]
  */
 /**
  * @template T
@@ -187,6 +195,7 @@ declare namespace ImageMinimizerPlugin {
     CustomOptions,
     InferDefaultType,
     BasicTransformerOptions,
+    ResizeOptions,
     BasicTransformerImplementation,
     BasicTransformerHelpers,
     TransformerFunction,
@@ -302,10 +311,18 @@ type CustomOptions = {
   [key: string]: any;
 };
 type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
-type BasicTransformerOptions<T> = InferDefaultType<T> | undefined;
+type BasicTransformerOptions<T> = {
+  resize?: ResizeOptions | undefined;
+  encodeOptions?: InferDefaultType<T> | undefined;
+};
+type ResizeOptions = {
+  width?: number | undefined;
+  height?: number | undefined;
+  enabled?: boolean | undefined;
+};
 type BasicTransformerImplementation<T> = (
   original: WorkerResult,
-  options?: BasicTransformerOptions<T>
+  options?: BasicTransformerOptions<T> | undefined
 ) => Promise<WorkerResult>;
 type BasicTransformerHelpers = {
   setup?: (() => void) | undefined;
@@ -322,7 +339,7 @@ type FilenameFn = (
 ) => string;
 type Transformer<T> = {
   implementation: TransformerFunction<T>;
-  options?: BasicTransformerOptions<T>;
+  options?: BasicTransformerOptions<T> | undefined;
   filter?: FilterFn | undefined;
   filename?: string | FilenameFn | undefined;
   preset?: string | undefined;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,9 +51,7 @@ export = ImageMinimizerPlugin;
  */
 /**
  * @template T
- * @typedef {Object} BasicTransformerOptions
- * @property {ResizeOptions} [resize]
- * @property {InferDefaultType<T>} [encodeOptions]
+ * @typedef {InferDefaultType<T> | undefined} BasicTransformerOptions
  */
 /**
  * @typedef {Object} ResizeOptions
@@ -311,10 +309,7 @@ type CustomOptions = {
   [key: string]: any;
 };
 type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
-type BasicTransformerOptions<T> = {
-  resize?: ResizeOptions | undefined;
-  encodeOptions?: InferDefaultType<T> | undefined;
-};
+type BasicTransformerOptions<T> = InferDefaultType<T> | undefined;
 type ResizeOptions = {
   width?: number | undefined;
   height?: number | undefined;
@@ -322,7 +317,7 @@ type ResizeOptions = {
 };
 type BasicTransformerImplementation<T> = (
   original: WorkerResult,
-  options?: BasicTransformerOptions<T> | undefined
+  options?: BasicTransformerOptions<T>
 ) => Promise<WorkerResult>;
 type BasicTransformerHelpers = {
   setup?: (() => void) | undefined;
@@ -339,7 +334,7 @@ type FilenameFn = (
 ) => string;
 type Transformer<T> = {
   implementation: TransformerFunction<T>;
-  options?: BasicTransformerOptions<T> | undefined;
+  options?: BasicTransformerOptions<T>;
   filter?: FilterFn | undefined;
   filename?: string | FilenameFn | undefined;
   preset?: string | undefined;

--- a/types/loader.d.ts
+++ b/types/loader.d.ts
@@ -10,7 +10,15 @@ declare function loader<T>(
   content: Buffer
 ): Promise<Buffer | undefined>;
 declare namespace loader {
-  export { raw, Schema, Compilation, WorkerResult, LoaderOptions };
+  export {
+    raw,
+    Schema,
+    Compilation,
+    WorkerResult,
+    Minimizer,
+    Generator,
+    LoaderOptions,
+  };
 }
 /**
  * <T>
@@ -30,3 +38,11 @@ declare var raw: boolean;
 type Schema = import("schema-utils/declarations/validate").Schema;
 type Compilation = import("webpack").Compilation;
 type WorkerResult = import("./utils").WorkerResult;
+/**
+ * <T>
+ */
+type Minimizer<T> = import("./index").Minimizer<T>;
+/**
+ * <T>
+ */
+type Generator<T> = import("./index").Generator<T>;


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Adds size query parameters to easier `<picture> srcset` usage. This feature is similar to [parceljs query-parameters](https://parceljs.org/languages/html/#images) for images.

```html
<picture>
  <source type="image/avif" srcset="./images/test1.jpg?as=avif&width=400, ./images/test1.jpg?as=avif&width=800 2x">
  <source type="image/webp" srcset="./images/test1.jpg?as=webp&width=400, ./images/test1.jpg?as=webp&width=800 2x">
  <source type="image/jpeg" srcset="./images/test1.jpg?width=400, ./images/test1.jpg?width=800 2x">
  <img src="./images/test1.jpg?width=400" width="400">
</picture>
```
```js
generator: [
  {
    preset: 'webp',
    implementation: ImageMinimizerPlugin.sharpGenerate,
    filename: 'generated-[name]-[width]x[height][ext]',
    options: {
      encodeOptions: {
        webp: {
          quality: 90,
        },
      },
    },
  },
  {
    preset: 'avif',
    implementation: ImageMinimizerPlugin.sharpGenerate,
    filename: 'generated-[name]-[width]x[height][ext]',
    options: {
      encodeOptions: {
        avif: {
          quality: 90,
        },
      },
    },
  },
],
```

### Breaking Changes

Works only with implementations that support the resizing option.
