### PR TITLE
fix(squoosh): fix resize option enabled flag

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -735,23 +735,18 @@ async function squooshGenerate(original, minifyOptions) {
 
   const squooshOptions = /** @type {SquooshOptions} */ (minifyOptions || {});
 
-  /**
-   * @type {undefined | Object.<string, any>}
-   */
-  let preprocessors;
-
-  for (const preprocessor of Object.keys(squoosh.preprocessors)) {
-    if (typeof squooshOptions[preprocessor] !== "undefined") {
-      if (!preprocessors) {
-        preprocessors = {};
+  const preprocEntries = Object.entries(squooshOptions).filter(
+    ([key, value]) => {
+      if (key === "resize" && value?.enabled === false) {
+        return false;
       }
 
-      preprocessors[preprocessor] = squooshOptions[preprocessor];
+      return typeof squoosh.preprocessors[key] !== "undefined";
     }
-  }
+  );
 
-  if (typeof preprocessors !== "undefined") {
-    await image.preprocess(preprocessors);
+  if (preprocEntries.length > 0) {
+    await image.preprocess(Object.fromEntries(preprocEntries));
   }
 
   const { encodeOptions } = squooshOptions;
@@ -860,23 +855,18 @@ async function squooshMinify(original, options) {
   const image = imagePool.ingestImage(new Uint8Array(original.data));
   const squooshOptions = /** @type {SquooshOptions} */ (options || {});
 
-  /**
-   * @type {undefined | Object.<string, any>}
-   */
-  let preprocessors;
-
-  for (const preprocessor of Object.keys(squoosh.preprocessors)) {
-    if (typeof squooshOptions[preprocessor] !== "undefined") {
-      if (!preprocessors) {
-        preprocessors = {};
+  const preprocEntries = Object.entries(squooshOptions).filter(
+    ([key, value]) => {
+      if (key === "resize" && value?.enabled === false) {
+        return false;
       }
 
-      preprocessors[preprocessor] = squooshOptions[preprocessor];
+      return typeof squoosh.preprocessors[key] !== "undefined";
     }
-  }
+  );
 
-  if (typeof preprocessors !== "undefined") {
-    await image.preprocess(preprocessors);
+  if (preprocEntries.length > 0) {
+    await image.preprocess(Object.fromEntries(preprocEntries));
   }
 
   const { encodeOptions = {} } = squooshOptions;

--- a/test/loader-generator-option.test.js
+++ b/test/loader-generator-option.test.js
@@ -240,6 +240,54 @@ describe("loader generator option", () => {
     expect(errors).toHaveLength(0);
   });
 
+  it("should generate and not resize (squooshGenerate)", async () => {
+    const stats = await runWebpack({
+      entry: path.join(fixturesPath, "./loader-single.js"),
+      imageminLoaderOptions: {
+        generator: [
+          {
+            preset: "webp",
+            implementation: ImageMinimizerPlugin.squooshGenerate,
+            options: {
+              resize: {
+                enabled: false,
+                width: 100,
+                height: 50,
+              },
+              rotate: {
+                numRotations: 90,
+              },
+              encodeOptions: {
+                webp: {
+                  lossless: 1,
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+
+    const transformedAsset = path.resolve(
+      __dirname,
+      compilation.options.output.path,
+      "./nested/deep/loader-test.webp"
+    );
+
+    const transformedExt = await fileType.fromFile(transformedAsset);
+    const sizeOf = promisify(imageSize);
+    const dimensions = await sizeOf(transformedAsset);
+
+    expect(dimensions.height).toBe(1);
+    expect(dimensions.width).toBe(1);
+    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(warnings).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+
   it("should generate and resize (sharpGenerate)", async () => {
     const stats = await runWebpack({
       entry: path.join(fixturesPath, "./loader-single.js"),
@@ -280,6 +328,51 @@ describe("loader generator option", () => {
 
     expect(dimensions.height).toBe(50);
     expect(dimensions.width).toBe(100);
+    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(warnings).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should generate and not resize (sharpGenerate)", async () => {
+    const stats = await runWebpack({
+      entry: path.join(fixturesPath, "./loader-single.js"),
+      imageminLoaderOptions: {
+        generator: [
+          {
+            preset: "webp",
+            implementation: ImageMinimizerPlugin.sharpGenerate,
+            options: {
+              resize: {
+                enabled: false,
+                width: 100,
+                height: 50,
+              },
+              encodeOptions: {
+                webp: {
+                  lossless: true,
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+
+    const transformedAsset = path.resolve(
+      __dirname,
+      compilation.options.output.path,
+      "./nested/deep/loader-test.webp"
+    );
+
+    const transformedExt = await fileType.fromFile(transformedAsset);
+    const sizeOf = promisify(imageSize);
+    const dimensions = await sizeOf(transformedAsset);
+
+    expect(dimensions.height).toBe(1);
+    expect(dimensions.width).toBe(1);
     expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fix `enabled` flag for `squoosh` resize option
```js
implementation: ImageMinimizerPlugin.squooshGenerate,
options: {
  resize: {
    enabled: false, // <- do not resize
    width: 100,
    height: 50,
  },
```