### PR TITLE
fix: better capability `sharp` and `squoosh` implementations

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -997,6 +997,14 @@ async function sharpTransform(
   const inputExt = path.extname(original.filename).slice(1).toLowerCase();
 
   if (!SHARP_FORMATS.has(inputExt)) {
+    if (targetFormat) {
+      const error = new Error(
+        `Error with '${original.filename}': Input file has an unsupported format`
+      );
+
+      original.errors.push(error);
+    }
+
     return null;
   }
 

--- a/test/ImageminPlugin.test.js
+++ b/test/ImageminPlugin.test.js
@@ -1515,7 +1515,7 @@ describe("imagemin plugin", () => {
     expect(/image\/png/i.test(ext.mime)).toBe(true);
   });
 
-  it("should throw an error on unknown format", async () => {
+  it("should throw an error on unknown format (squooshGenerate)", async () => {
     const stats = await runWebpack({
       entry: path.join(fixturesPath, "generator-and-minimizer-5.js"),
       imageminPluginOptions: {
@@ -1542,6 +1542,36 @@ describe("imagemin plugin", () => {
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toMatch(
       /Error with 'loader-test.txt': Binary blob has an unsupported format/g
+    );
+  });
+
+  it("should throw an error on unknown format (sharpGenerate)", async () => {
+    const stats = await runWebpack({
+      entry: path.join(fixturesPath, "generator-and-minimizer-5.js"),
+      imageminPluginOptions: {
+        test: /\.(jpe?g|gif|json|svg|png|webp|txt)$/i,
+        generator: [
+          {
+            preset: "avif",
+            implementation: ImageMinimizerPlugin.sharpGenerate,
+            options: {
+              encodeOptions: {
+                webp: {
+                  lossless: true,
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const { compilation } = stats;
+    const { warnings, errors } = compilation;
+
+    expect(warnings).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(
+      /Error with 'loader-test.txt': Input file has an unsupported format/g
     );
   });
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

`squoosh` throws an unknown format error when using a generator, but not when using a minimizer.
`sharp` also now follows this behavior.
