### PR TITLE
fix: empty svgo file path

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1228,13 +1228,16 @@ async function svgoMinify(original, minimizerOptions) {
   // eslint-disable-next-line node/no-unpublished-require
   const { optimize } = require("svgo");
 
-  const { encodeOptions } = /** @type {SvgoOptions} */ (minimizerOptions);
+  const { encodeOptions = {} } = /** @type {SvgoOptions} */ (minimizerOptions);
 
   /** @type {import("svgo").Output} */
   let result;
 
   try {
-    result = optimize(original.data.toString(), encodeOptions);
+    result = optimize(original.data.toString(), {
+      path: original.filename,
+      ...encodeOptions,
+    });
   } catch (error) {
     const originalError =
       error instanceof Error ? error : new Error(/** @type {string} */ (error));


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Some `svgo` plugins use `config.path` property, e.g `prefixIds` plugin.
https://github.com/svg/svgo/blob/main/lib/svgo.js#L59-L61
https://github.com/svg/svgo/blob/main/plugins/prefixIds.js#L108-L110

### Breaking Changes

no

### Additional Info
