### PR TITLE
docs(readme): updating instructions for use

### DIFF
--- a/README.md
+++ b/README.md
@@ -2461,6 +2461,7 @@ module.exports = {
         generator: [
           {
             // You can apply generator using `?as=webp`, you can use any name and provide more options
+            type: 'asset',
             preset: "webp",
             implementation: ImageMinimizerPlugin.squooshGenerate,
             options: {


### PR DESCRIPTION
docs(readme): updating instructions for use

### Motivation / Use-Case

Add type property for webpack to work correctly when converting files to webp format.

### Breaking Changes

This addition helped me solve the problem of converting images to webp format when building a project. I hope this add-on will also help other developers when working with webpack.
