### PR TITLE
fix: webpack compilations fail when using filesystem cache, #458

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -204,10 +204,12 @@ async function loader(content) {
   }
 
   let isAbsolute = isAbsoluteURL(this.resourcePath);
+  const isData = this.resourcePath.startsWith("DATA:");
+  const shouldMakeRelative = !isData && isAbsolute;
 
-  const filename = isAbsolute
-    ? this.resourcePath
-    : path.relative(this.rootContext, this.resourcePath);
+  const filename = shouldMakeRelative
+    ? path.relative(this.rootContext, this.resourcePath)
+    : this.resourcePath;
 
   const minifyOptions =
     /** @type {import("./index").InternalWorkerOptions<T>} */ ({

--- a/test/ImageminPlugin.test.js
+++ b/test/ImageminPlugin.test.js
@@ -919,7 +919,7 @@ describe("imagemin plugin", () => {
     const stringStats = stats.toString({ relatedAssets: true });
 
     expect(stringStats).toMatch(
-      /asset loader-test.webp.+\[from: .+loader-test.png\] \[generated\]/,
+      /asset loader-test.webp.+\[from: .*loader-test.png\] \[generated\]/,
     );
   });
 
@@ -1386,7 +1386,7 @@ describe("imagemin plugin", () => {
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toMatch(
-      /Multiple values for the 'encodeOptions' option is not supported for '.+loader-test.png', specify only one codec for the generator/,
+      /Multiple values for the 'encodeOptions' option is not supported for '.*loader-test.png', specify only one codec for the generator/,
     );
   });
 
@@ -1771,7 +1771,7 @@ describe("imagemin plugin", () => {
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toMatch(
-      /Error with '.+loader-test.txt': Input file has an unsupported format/g,
+      /Error with '.*loader-test.txt': Input file has an unsupported format/g,
     );
   });
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

There is the Bugfix for the issue [Webpack compilations fail when using filesystem cache](#458).

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
