### PR TITLE
perf(caching): improves caching of loader and optimizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
     "node": ">= 18.12.0"
   },
   "scripts": {
-    "start": "npm run build -- -w",
+    "start": "npm-run-all -p \"watch:**\"",
     "clean": "del-cli dist types",
     "prebuild": "npm run clean",
     "build:types": "tsc --declaration --emitDeclarationOnly && prettier \"types/**/*.ts\" --write",
+    "postbuild:types": "prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",
     "build": "npm-run-all -p \"build:**\"",
+    "watch:types": "npm run build:types -- -w",
+    "watch:code": "npm run build:code -- -w",
     "commitlint": "commitlint --from=master",
     "security": "npm audit --production",
     "lint:prettier": "prettier --cache --list-different .",

--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,6 @@ class ImageMinimizerPlugin {
     }
 
     const cache = compilation.getCache("ImageMinimizerWebpackPlugin");
-
     const assetsForTransformers = (
       await Promise.all(
         Object.keys(assets)
@@ -294,7 +293,7 @@ class ImageMinimizerPlugin {
                 })),
               });
 
-              const cacheItem = cache.getItemCache(cacheName, null);
+              const cacheItem = cache.getItemCache(cacheName, eTag);
               const output = await cacheItem.getPromise();
 
               return {
@@ -340,7 +339,7 @@ class ImageMinimizerPlugin {
       1,
       this.options.concurrency ?? os.cpus()?.length ?? 1,
     );
-    const { RawSource, CachedSource } = compiler.webpack.sources;
+    const { RawSource } = compiler.webpack.sources;
 
     const scheduledTasks = assetsForTransformers.map((asset) => async () => {
       const { name, info, inputSource, cacheItem, transformer } = asset;
@@ -377,7 +376,7 @@ class ImageMinimizerPlugin {
 
           return {
             data: result.data,
-            source: new CachedSource(new RawSource(result.data)),
+            source: new RawSource(result.data),
             info: result.info,
             filename: result.filename,
             warnings: result.warnings,


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

#### 1. Performance refactor / race-condition fix:

This PR eliminates the race condition where the loader or optimizer may do the same processing (same transformation on the same image) redundantly if the same file transformation's loader is triggered more than once before the first transformation has finished.

#### 2. Fix `npm start`

Didn't work before; now it does. (With as little change to the prior scripts as possible.)

### Breaking Changes

None that I'm aware of.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

This PR doesn't eliminate all possible such race conditions, namely if the same image transformation occurs between the loader and the minimizer, because the transformers are different functions (because the minimizer functionality is different than the generator/loader, even though the underlying operation is the same), it's still possible to have redundant image transformations if one transformation happens via the loader, and the same transformation happens via the webpack optimize hook.