### PR TITLE
feat(cacheDir): add caching independent of webpack's caching

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -43,7 +43,8 @@
     "libvips",
     "hspace",
     "commitlint",
-    "nodenext"
+    "nodenext",
+    "eslintcache"
   ],
 
   "ignorePaths": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.cache
 coverage
 .vscode
 logs

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ with option `"markdown.extension.toc.levels": "2..6"`
 - [Plugin Options](#plugin-options)
   - [`test`](#test)
   - [`include`](#include)
+  - [`cacheDir`](#cachedir)
   - [`exclude`](#exclude)
   - [`minimizer`](#minimizer)
     - [Available minimizers](#available-minimizers)
@@ -76,6 +77,7 @@ with option `"markdown.extension.toc.levels": "2..6"`
   - [`generator`](#generator-1)
     - [Loader generator example for `imagemin`](#loader-generator-example-for-imagemin)
   - [`severityError`](#severityerror-1)
+  - [`cacheDir`](#cachedir-1)
 - [Additional API](#additional-api)
   - [`imageminNormalizeConfig(config)`](#imageminnormalizeconfigconfig)
 - [Examples](#examples)
@@ -693,6 +695,35 @@ module.exports = {
       "...",
       new ImageMinimizerPlugin({
         exclude: /\/excludes/,
+      }),
+    ],
+  },
+};
+```
+
+### `cacheDir`
+
+Type:
+
+```ts
+type cacheDir = string;
+```
+
+Default: `undefined`
+
+If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)
+
+**webpack.config.js**
+
+```js
+const ImageMinimizerPlugin = require("image-minimizer-webpack-plugin");
+
+module.exports = {
+  optimization: {
+    minimizer: [
+      "...",
+      new ImageMinimizerPlugin({
+        cacheDir: ".cache/image-minimizer",
       }),
     ],
   },
@@ -2344,6 +2375,49 @@ module.exports = {
             loader: ImageMinimizerPlugin.loader,
             options: {
               severityError: "warning",
+              minimizerOptions: {
+                plugins: ["gifsicle"],
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+### `cacheDir`
+
+Type:
+
+```ts
+type cacheDir = string;
+```
+
+Default: `undefined`
+
+If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)
+
+**webpack.config.js**
+
+```js
+const ImageMinimizerPlugin = require("image-minimizer-webpack-plugin");
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(jpe?g|png|gif|svg)$/i,
+        type: "asset",
+      },
+      {
+        test: /\.(jpe?g|png|gif|svg)$/i,
+        use: [
+          {
+            loader: ImageMinimizerPlugin.loader,
+            options: {
+              cacheDir: ".cache/image-minimizer",
               minimizerOptions: {
                 plugins: ["gifsicle"],
               },

--- a/README.md
+++ b/README.md
@@ -730,6 +730,35 @@ module.exports = {
 };
 ```
 
+### `bypassWebpackCache`
+
+Type:
+
+```ts
+type bypassWebpackCache = string;
+```
+
+Default: `undefined`
+
+If `true`, skips using Webpack's cache. (Typically useful if you're using the `cacheDir` and therefore don't need to double-up on caching with Webpack's cache.)
+
+**webpack.config.js**
+
+```js
+const ImageMinimizerPlugin = require("image-minimizer-webpack-plugin");
+
+module.exports = {
+  optimization: {
+    minimizer: [
+      "...",
+      new ImageMinimizerPlugin({
+        bypassWebpackCache: true,
+      }),
+    ],
+  },
+};
+```
+
 ### `minimizer`
 
 Type:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,12 @@
       "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
+        "graceful-fs": "^4.2.11",
+        "mkdirp": "^3.0.1",
+        "proper-lockfile": "^4.1.2",
         "schema-utils": "^4.2.0",
-        "serialize-javascript": "^6.0.2"
+        "serialize-javascript": "^6.0.2",
+        "stream-buffers": "^3.0.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.24.7",
@@ -19,10 +23,13 @@
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
         "@squoosh/lib": "^0.5.3",
+        "@types/graceful-fs": "^4.1.9",
         "@types/imagemin": "^9.0.0",
         "@types/node": "^20.14.9",
+        "@types/proper-lockfile": "^4.1.4",
         "@types/serialize-javascript": "^5.0.4",
         "@types/sharp": "^0.32.0",
+        "@types/stream-buffers": "^3.0.7",
         "@webpack-contrib/eslint-config-webpack": "^3.0.0",
         "babel-jest": "^29.7.0",
         "copy-webpack-plugin": "^12.0.2",
@@ -5066,6 +5073,21 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -5093,6 +5115,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.7.tgz",
+      "integrity": "sha512-azOCy05sXVXrO+qklf0c/B07H/oHaIuDDAiHPVwlk3A9Ek+ksHyTeMajLZl3r76FxpPpxem//4Te61G1iW3Giw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/supports-color": {
       "version": "8.1.3",
@@ -13359,8 +13390,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -18307,6 +18337,20 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -19693,6 +19737,21 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/propose": {
       "version": "0.0.5",
@@ -21106,7 +21165,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -21913,6 +21971,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/strict-uri-encode": {

--- a/package.json
+++ b/package.json
@@ -72,8 +72,12 @@
     }
   },
   "dependencies": {
+    "graceful-fs": "^4.2.11",
+    "mkdirp": "^3.0.1",
+    "proper-lockfile": "^4.1.2",
     "schema-utils": "^4.2.0",
-    "serialize-javascript": "^6.0.2"
+    "serialize-javascript": "^6.0.2",
+    "stream-buffers": "^3.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.7",
@@ -82,10 +86,13 @@
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@squoosh/lib": "^0.5.3",
+    "@types/graceful-fs": "^4.1.9",
     "@types/imagemin": "^9.0.0",
     "@types/node": "^20.14.9",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/serialize-javascript": "^5.0.4",
     "@types/sharp": "^0.32.0",
+    "@types/stream-buffers": "^3.0.7",
     "@webpack-contrib/eslint-config-webpack": "^3.0.0",
     "babel-jest": "^29.7.0",
     "copy-webpack-plugin": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
     "node": ">= 18.12.0"
   },
   "scripts": {
-    "start": "npm run build -- -w",
+    "start": "npm-run-all -p \"watch:**\"",
     "clean": "del-cli dist types",
     "prebuild": "npm run clean",
     "build:types": "tsc --declaration --emitDeclarationOnly && prettier \"types/**/*.ts\" --write",
+    "postbuild:types": "prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",
     "build": "npm-run-all -p \"build:**\"",
+    "watch:types": "npm run build:types -- -w",
+    "watch:code": "npm run build:code -- -w",
     "commitlint": "commitlint --from=master",
     "security": "npm audit --production",
     "lint:prettier": "prettier --cache --list-different .",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "npm-run-all -p \"watch:**\"",
     "clean": "del-cli dist types",
     "prebuild": "npm run clean",
-    "build:types": "tsc --declaration --emitDeclarationOnly && prettier \"types/**/*.ts\" --write",
+    "build:types": "tsc --declaration --emitDeclarationOnly",
     "postbuild:types": "prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",
     "build": "npm-run-all -p \"build:**\"",

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,156 @@
+const { createHash } = require("crypto");
+const path = require("path");
+const { promisify } = require("util");
+const fs = require("graceful-fs");
+const { mkdirp } = require("mkdirp");
+const { WritableStreamBuffer } = require("stream-buffers");
+
+const close = promisify(fs.close);
+const open = promisify(fs.open);
+const readFile = promisify(fs.readFile);
+const stat = promisify(fs.stat);
+const unlink = promisify(fs.unlink);
+const utimes = promisify(fs.utimes);
+
+const { lock } = require("proper-lockfile");
+
+const cleanups = new Set();
+
+// eslint-disable-next-line jest/require-hook
+process.on("exit", () => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+});
+
+/**
+ * @template T
+ * @typedef {import("webpack").LoaderContext<T>} LoaderContext<T>
+ * */
+
+/**
+ * @typedef {import("stream").Writable} Writable
+ * */
+
+/**
+ * @typedef {import("crypto").BinaryLike} BinaryLike
+ * */
+
+/**
+ * @typedef {import("buffer").Buffer} Buffer
+ * */
+
+// let lockCount = 0;
+/**
+ * @template T
+ * @param {string} file
+ * @param {() => Promise<T>} cb
+ * @returns {Promise<T | undefined>}
+ */
+async function lockAndExecuteOnce(file, cb) {
+  let lockFile = file;
+
+  try {
+    await stat(file);
+  } catch {
+    lockFile = `${file}_lock`;
+
+    try {
+      const time = new Date();
+
+      await utimes(lockFile, time, time);
+    } catch {
+      try {
+        await close(await open(lockFile, "w"));
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  const releaseLock = await lock(lockFile, { fs, retries: 10 });
+
+  const cleanup = async () => {
+    cleanups.delete(cleanup);
+
+    await releaseLock();
+
+    if (lockFile !== file) {
+      try {
+        await unlink(lockFile);
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  cleanups.add(cleanup);
+
+  try {
+    return await cb();
+  } finally {
+    cleanup();
+  }
+}
+
+/** @param {BinaryLike} content */
+export function hashContent(content) {
+  return createHash("sha1").update(content).digest("hex");
+}
+
+/**
+ * @param {Buffer} content
+ * @param {(resultWriteable: Writable) => Promise<void>} processContent
+ * @param {string} [cacheDir] If provided, will attempt to read the corresponding cached file instead of calling
+ * processContent.
+ * @returns {Promise<Buffer | undefined>}
+ */
+export async function processAndMaybeCacheContent(
+  content,
+  processContent,
+  cacheDir,
+) {
+  if (cacheDir) {
+    const cacheFile = path.resolve(
+      path.join(cacheDir, hashContent(/** @type {BinaryLike} */ (content))),
+    );
+
+    try {
+      await stat(path.dirname(cacheFile));
+    } catch {
+      await mkdirp(path.dirname(cacheFile));
+    }
+
+    return /** @type {Promise<Buffer>} */ (
+      lockAndExecuteOnce(cacheFile, async () => {
+        try {
+          await stat(cacheFile);
+        } catch {
+          // this cleanup is for if the writing to the cache file gets _interrupted_ (by a kill signal or the like), to
+          // ensure we don't allow a partially generated file to be used as the cached file.
+          const cleanup = () => {
+            unlink(cacheFile);
+          };
+
+          cleanups.add(cleanup);
+
+          await processContent(fs.createWriteStream(cacheFile));
+
+          cleanups.delete(cleanup);
+        }
+
+        return readFile(cacheFile);
+      })
+    );
+  }
+
+  const outputStreamBuffer = new WritableStreamBuffer();
+
+  await processContent(outputStreamBuffer);
+
+  const output = outputStreamBuffer.getContents();
+
+  if (output) {
+    return output;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,6 @@ class ImageMinimizerPlugin {
     }
 
     const cache = compilation.getCache("ImageMinimizerWebpackPlugin");
-
     const assetsForTransformers = (
       await Promise.all(
         Object.keys(assets)
@@ -294,7 +293,7 @@ class ImageMinimizerPlugin {
                 })),
               });
 
-              const cacheItem = cache.getItemCache(cacheName, null);
+              const cacheItem = cache.getItemCache(cacheName, eTag);
               const output = await cacheItem.getPromise();
 
               return {
@@ -340,7 +339,7 @@ class ImageMinimizerPlugin {
       1,
       this.options.concurrency ?? os.cpus()?.length ?? 1,
     );
-    const { RawSource, CachedSource } = compiler.webpack.sources;
+    const { RawSource } = compiler.webpack.sources;
 
     const scheduledTasks = assetsForTransformers.map((asset) => async () => {
       const { name, info, inputSource, cacheItem, transformer } = asset;
@@ -377,7 +376,7 @@ class ImageMinimizerPlugin {
 
           return {
             data: result.data,
-            source: new CachedSource(new RawSource(result.data)),
+            source: new RawSource(result.data),
             info: result.info,
             filename: result.filename,
             warnings: result.warnings,

--- a/src/loader-options.json
+++ b/src/loader-options.json
@@ -106,6 +106,11 @@
       "description": "Allows to choose how errors are displayed.",
       "link": "https://github.com/webpack-contrib/image-minimizer-webpack-plugin#severityerror",
       "enum": ["off", "warning", "error"]
+    },
+    "cacheDir": {
+      "description": "If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)",
+      "link": "https://github.com/webpack-contrib/image-minimizer-webpack-plugin#cachedir",
+      "type": "string"
     }
   }
 }

--- a/src/loader-options.json
+++ b/src/loader-options.json
@@ -111,6 +111,11 @@
       "description": "If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)",
       "link": "https://github.com/webpack-contrib/image-minimizer-webpack-plugin#cachedir",
       "type": "string"
+    },
+    "bypassWebpackCache": {
+      "description": "If true, skips using Webpack's cache.",
+      "link": "https://github.com/webpack-contrib/image-minimizer-webpack-plugin#bypasswebpackcache",
+      "type": "boolean"
     }
   }
 }

--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -183,6 +183,11 @@
       "description": "If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)",
       "link": "https://github.com/webpack-contrib/image-minimizer-webpack-plugin#cachedir",
       "type": "string"
+    },
+    "bypassWebpackCache": {
+      "description": "If true, skips using Webpack's cache.",
+      "link": "https://github.com/webpack-contrib/image-minimizer-webpack-plugin#bypasswebpackcache",
+      "type": "boolean"
     }
   }
 }

--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -178,6 +178,11 @@
       "type": "boolean",
       "description": "Allows to remove original assets after minimization.",
       "link": "https://github.com/webpack-contrib/image-minimizer-webpack-plugin#deleteoriginalassets"
+    },
+    "cacheDir": {
+      "description": "If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)",
+      "link": "https://github.com/webpack-contrib/image-minimizer-webpack-plugin#cachedir",
+      "type": "string"
     }
   }
 }

--- a/test/ImageminPlugin.test.js
+++ b/test/ImageminPlugin.test.js
@@ -755,6 +755,7 @@ describe("imagemin plugin", () => {
                 preset: "webp",
                 implementation: ImageMinimizerPlugin.sharpGenerate,
                 options: {
+                  cacheDir: ".cache/image-minimizer",
                   encodeOptions: {
                     webp: {
                       lossless: true,
@@ -804,8 +805,8 @@ describe("imagemin plugin", () => {
       path.resolve(outputDir, "plugin-test.jpg"),
     );
 
-    expect(/image\/webp/i.test(extLoaderWebp.mime)).toBe(true);
-    expect(/image\/jpeg/i.test(extLoaderJpg.mime)).toBe(true);
+    expect(extLoaderWebp.mime).toMatch(/image\/webp/i);
+    expect(extLoaderJpg.mime).toMatch(/image\/jpeg/i);
     expect(secondStats.compilation.emittedAssets.size).toBe(0);
   });
 
@@ -816,7 +817,10 @@ describe("imagemin plugin", () => {
       imageminPluginOptions: {
         minimizer: {
           implementation: ImageMinimizerPlugin.imageminMinify,
-          options: { plugins },
+          options: {
+            cacheDir: ".cache/image-minimizer",
+            plugins,
+          },
         },
       },
     });
@@ -842,6 +846,7 @@ describe("imagemin plugin", () => {
             implementation: ImageMinimizerPlugin.imageminMinify,
             options: { plugins },
           },
+          cacheDir: ".cache/image-minimizer",
         },
       },
       true,
@@ -962,7 +967,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
 
     await expect(isOptimized("loader-test.gif", compilation)).resolves.toBe(
       true,
@@ -1026,7 +1031,7 @@ describe("imagemin plugin", () => {
       );
       const ext = await fileType.fromFile(file);
 
-      expect(/image\/webp/i.test(ext.mime)).toBe(true);
+      expect(ext.mime).toMatch(/image\/webp/i);
 
       // TODO fix me
       await expect(isOptimized("loader-test.gif", compilation)).resolves.toBe(
@@ -1205,7 +1210,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
 
     // TODO fix me
     await expect(isOptimized("loader-test.gif", compilation)).resolves.toBe(
@@ -1251,7 +1256,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/avif/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/avif/i);
   });
 
   it("should generate and allow to use any name in the 'preset' option using 'imageminGenerate'", async () => {
@@ -1283,7 +1288,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
   });
 
   ifit(needSquooshTest)(
@@ -1321,7 +1326,7 @@ describe("imagemin plugin", () => {
       );
       const ext = await fileType.fromFile(file);
 
-      expect(/image\/webp/i.test(ext.mime)).toBe(true);
+      expect(ext.mime).toMatch(/image\/webp/i);
     },
   );
 
@@ -1468,7 +1473,7 @@ describe("imagemin plugin", () => {
 
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
 
     const webpAsset = compilation.getAsset("loader-test.webp");
 
@@ -1546,7 +1551,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(webpAsset);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
 
     const webpAsset1 = path.resolve(
       __dirname,
@@ -1555,7 +1560,7 @@ describe("imagemin plugin", () => {
     );
     const ext1 = await fileType.fromFile(webpAsset1);
 
-    expect(/image\/webp/i.test(ext1.mime)).toBe(true);
+    expect(ext1.mime).toMatch(/image\/webp/i);
 
     const webpAsset2 = path.resolve(
       __dirname,
@@ -1564,7 +1569,7 @@ describe("imagemin plugin", () => {
     );
     const ext2 = await fileType.fromFile(webpAsset2);
 
-    expect(/image\/webp/i.test(ext2.mime)).toBe(true);
+    expect(ext2.mime).toMatch(/image\/webp/i);
 
     await expect(
       isOptimized(
@@ -1647,7 +1652,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(webpAsset);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
 
     await expect(
       isOptimized(
@@ -1709,7 +1714,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/png/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/png/i);
   });
 
   ifit(needSquooshTest)(
@@ -1844,7 +1849,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/avif/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/avif/i);
   });
 
   it("should generate image for 'asset' type", async () => {
@@ -1878,7 +1883,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/avif/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/avif/i);
   });
 
   it("should not throw an error when no presets found using the `asset` type", async () => {
@@ -1911,7 +1916,7 @@ describe("imagemin plugin", () => {
     );
     const loaderExt = await fileType.fromFile(loaderFile);
 
-    expect(/image\/avif/i.test(loaderExt.mime)).toBe(true);
+    expect(loaderExt.mime).toMatch(/image\/avif/i);
   });
 
   it("should generate image for 'import' and 'asset' types", async () => {
@@ -1954,7 +1959,7 @@ describe("imagemin plugin", () => {
     );
     const loaderExt = await fileType.fromFile(loaderFile);
 
-    expect(/image\/avif/i.test(loaderExt.mime)).toBe(true);
+    expect(loaderExt.mime).toMatch(/image\/avif/i);
 
     const pluginFile = path.resolve(
       __dirname,
@@ -1963,7 +1968,7 @@ describe("imagemin plugin", () => {
     );
     const pluginExt = await fileType.fromFile(pluginFile);
 
-    expect(/image\/avif/i.test(pluginExt.mime)).toBe(true);
+    expect(pluginExt.mime).toMatch(/image\/avif/i);
   });
 
   it("should generate images for 'import' and 'asset' types and keep original assets", async () => {
@@ -2008,7 +2013,7 @@ describe("imagemin plugin", () => {
     );
     const loaderExt = await fileType.fromFile(loaderFile);
 
-    expect(/image\/avif/i.test(loaderExt.mime)).toBe(true);
+    expect(loaderExt.mime).toMatch(/image\/avif/i);
 
     const pluginFile = path.resolve(
       __dirname,
@@ -2017,7 +2022,7 @@ describe("imagemin plugin", () => {
     );
     const pluginExt = await fileType.fromFile(pluginFile);
 
-    expect(/image\/avif/i.test(pluginExt.mime)).toBe(true);
+    expect(pluginExt.mime).toMatch(/image\/avif/i);
   });
 
   it("should generate image for 'import' and 'asset' types, minimizer original asset and keep", async () => {
@@ -2068,7 +2073,7 @@ describe("imagemin plugin", () => {
     );
     const loaderExt = await fileType.fromFile(loaderFile);
 
-    expect(/image\/avif/i.test(loaderExt.mime)).toBe(true);
+    expect(loaderExt.mime).toMatch(/image\/avif/i);
 
     const pluginFile = path.resolve(
       __dirname,
@@ -2077,7 +2082,7 @@ describe("imagemin plugin", () => {
     );
     const pluginExt = await fileType.fromFile(pluginFile);
 
-    expect(/image\/avif/i.test(pluginExt.mime)).toBe(true);
+    expect(pluginExt.mime).toMatch(/image\/avif/i);
 
     await expect(isOptimized("plugin-test.jpg", compilation)).resolves.toBe(
       true,
@@ -2140,7 +2145,7 @@ describe("imagemin plugin", () => {
     );
     const loaderExt = await fileType.fromFile(loaderFile);
 
-    expect(/image\/avif/i.test(loaderExt.mime)).toBe(true);
+    expect(loaderExt.mime).toMatch(/image\/avif/i);
 
     const pluginFile = path.resolve(
       __dirname,
@@ -2149,7 +2154,7 @@ describe("imagemin plugin", () => {
     );
     const pluginExt = await fileType.fromFile(pluginFile);
 
-    expect(/image\/avif/i.test(pluginExt.mime)).toBe(true);
+    expect(pluginExt.mime).toMatch(/image\/avif/i);
 
     const pluginWebp = path.resolve(
       __dirname,
@@ -2158,7 +2163,7 @@ describe("imagemin plugin", () => {
     );
     const pluginWebExt = await fileType.fromFile(pluginWebp);
 
-    expect(/image\/webp/i.test(pluginWebExt.mime)).toBe(true);
+    expect(pluginWebExt.mime).toMatch(/image\/webp/i);
 
     await expect(isOptimized("plugin-test.jpg", compilation)).resolves.toBe(
       true,
@@ -2237,7 +2242,7 @@ describe("imagemin plugin", () => {
     );
     const loaderExt = await fileType.fromFile(loaderFile);
 
-    expect(/image\/avif/i.test(loaderExt.mime)).toBe(true);
+    expect(loaderExt.mime).toMatch(/image\/avif/);
 
     const pluginFile = path.resolve(
       __dirname,
@@ -2246,7 +2251,7 @@ describe("imagemin plugin", () => {
     );
     const pluginExt = await fileType.fromFile(pluginFile);
 
-    expect(/image\/avif/i.test(pluginExt.mime)).toBe(true);
+    expect(pluginExt.mime).toMatch(/image\/avif/i);
 
     const pluginWebp = path.resolve(
       __dirname,
@@ -2255,7 +2260,7 @@ describe("imagemin plugin", () => {
     );
     const pluginWebExt = await fileType.fromFile(pluginWebp);
 
-    expect(/image\/webp/i.test(pluginWebExt.mime)).toBe(true);
+    expect(pluginWebExt.mime).toMatch(/image\/webp/i);
 
     // await expect(isOptimized("plugin-test.jpg", compilation)).resolves.toBe(
     //     true
@@ -2327,7 +2332,7 @@ describe("imagemin plugin", () => {
     );
     const loaderExt = await fileType.fromFile(loaderFile);
 
-    expect(/image\/avif/i.test(loaderExt.mime)).toBe(true);
+    expect(loaderExt.mime).toMatch(/image\/avif/i);
 
     const pluginFile = path.resolve(
       __dirname,
@@ -2336,7 +2341,7 @@ describe("imagemin plugin", () => {
     );
     const pluginExt = await fileType.fromFile(pluginFile);
 
-    expect(/image\/avif/i.test(pluginExt.mime)).toBe(true);
+    expect(pluginExt.mime).toMatch(/image\/avif/i);
 
     const pluginWebp = path.resolve(
       __dirname,
@@ -2345,7 +2350,7 @@ describe("imagemin plugin", () => {
     );
     const pluginWebExt = await fileType.fromFile(pluginWebp);
 
-    expect(/image\/webp/i.test(pluginWebExt.mime)).toBe(true);
+    expect(pluginWebExt.mime).toMatch(/image\/webp/i);
 
     await expect(isOptimized("plugin-test.jpg", compilation)).resolves.toBe(
       true,
@@ -2398,7 +2403,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
   });
 
   it("should generate image from copied assets, minimize and keep original", async () => {
@@ -2444,7 +2449,7 @@ describe("imagemin plugin", () => {
     );
     const webpExt = await fileType.fromFile(webpFile);
 
-    expect(/image\/webp/i.test(webpExt.mime)).toBe(true);
+    expect(webpExt.mime).toMatch(/image\/webp/i);
 
     const fileJpg = path.resolve(
       __dirname,
@@ -2453,7 +2458,7 @@ describe("imagemin plugin", () => {
     );
     const extJpg = await fileType.fromFile(fileJpg);
 
-    expect(/image\/jpeg/i.test(extJpg.mime)).toBe(true);
+    expect(extJpg.mime).toMatch(/image\/jpeg/i);
 
     await expect(isOptimized("plugin-test.jpg", compilation)).resolves.toBe(
       true,
@@ -2515,7 +2520,7 @@ describe("imagemin plugin", () => {
     // );
     // const pngExt = await fileType.fromFile(pngFile);
     //
-    // expect(/image\/png/i.test(pngExt.mime)).toBe(true);
+    // expect(pngExt.mime).toMatch(/image\/png/i);
     //
     // const webpFile = path.resolve(
     //   __dirname,
@@ -2524,7 +2529,7 @@ describe("imagemin plugin", () => {
     // );
     // const webpExt = await fileType.fromFile(webpFile);
     //
-    // expect(/image\/webp/i.test(webpExt.mime)).toBe(true);
+    // expect(webpExt.mime).toMatch(/image\/webp/i);
     //
     const cssFile = path.resolve(
       __dirname,
@@ -2634,7 +2639,7 @@ describe("imagemin plugin", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
   });
 
   it("should optimizes images svg image and prefix id (svgoMinify)", async () => {

--- a/test/ImageminPlugin.test.js
+++ b/test/ImageminPlugin.test.js
@@ -846,7 +846,6 @@ describe("imagemin plugin", () => {
             implementation: ImageMinimizerPlugin.imageminMinify,
             options: { plugins },
           },
-          cacheDir: ".cache/image-minimizer",
         },
       },
       true,
@@ -1054,6 +1053,8 @@ describe("imagemin plugin", () => {
       entry: path.join(fixturesPath, "generator-and-minimizer-animation.js"),
       imageminPluginOptions: {
         test: /\.(jpe?g|png|webp|gif)$/i,
+        cacheDir: ".cache/image-minimizer",
+        bypassWebpackCache: true,
         generator: [
           {
             preset: "webp",

--- a/test/__snapshots__/validate-loader-options.test.js.snap
+++ b/test/__snapshots__/validate-loader-options.test.js.snap
@@ -183,47 +183,47 @@ exports[`validate loader options should throw an error on the "severityError" op
 exports[`validate loader options should throw an error on the "unknown" option with "/test/" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError?, cacheDir? }"
+   object { minimizer?, generator?, severityError?, cacheDir?, bypassWebpackCache? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "[]" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError?, cacheDir? }"
+   object { minimizer?, generator?, severityError?, cacheDir?, bypassWebpackCache? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError?, cacheDir? }"
+   object { minimizer?, generator?, severityError?, cacheDir?, bypassWebpackCache? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "{}" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError?, cacheDir? }"
+   object { minimizer?, generator?, severityError?, cacheDir?, bypassWebpackCache? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "1" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError?, cacheDir? }"
+   object { minimizer?, generator?, severityError?, cacheDir?, bypassWebpackCache? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "false" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError?, cacheDir? }"
+   object { minimizer?, generator?, severityError?, cacheDir?, bypassWebpackCache? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "test" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError?, cacheDir? }"
+   object { minimizer?, generator?, severityError?, cacheDir?, bypassWebpackCache? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "true" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError?, cacheDir? }"
+   object { minimizer?, generator?, severityError?, cacheDir?, bypassWebpackCache? }"
 `;

--- a/test/__snapshots__/validate-loader-options.test.js.snap
+++ b/test/__snapshots__/validate-loader-options.test.js.snap
@@ -183,47 +183,47 @@ exports[`validate loader options should throw an error on the "severityError" op
 exports[`validate loader options should throw an error on the "unknown" option with "/test/" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError? }"
+   object { minimizer?, generator?, severityError?, cacheDir? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "[]" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError? }"
+   object { minimizer?, generator?, severityError?, cacheDir? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError? }"
+   object { minimizer?, generator?, severityError?, cacheDir? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "{}" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError? }"
+   object { minimizer?, generator?, severityError?, cacheDir? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "1" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError? }"
+   object { minimizer?, generator?, severityError?, cacheDir? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "false" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError? }"
+   object { minimizer?, generator?, severityError?, cacheDir? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "test" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError? }"
+   object { minimizer?, generator?, severityError?, cacheDir? }"
 `;
 
 exports[`validate loader options should throw an error on the "unknown" option with "true" value 1`] = `
 "Invalid options object. Image Minimizer Plugin Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { minimizer?, generator?, severityError? }"
+   object { minimizer?, generator?, severityError?, cacheDir? }"
 `;

--- a/test/loader-generator-option.test.js
+++ b/test/loader-generator-option.test.js
@@ -40,7 +40,7 @@ describe("loader generator option", () => {
 
     const transformedExt = await fileType.fromFile(transformedAsset);
 
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/webp/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
@@ -148,7 +148,7 @@ describe("loader generator option", () => {
 
     const transformedExt = await fileType.fromFile(transformedAsset);
 
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/webp/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
@@ -187,7 +187,7 @@ describe("loader generator option", () => {
 
     const transformedExt = await fileType.fromFile(transformedAsset);
 
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/webp/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
@@ -237,7 +237,7 @@ describe("loader generator option", () => {
 
       expect(dimensions.height).toBe(50);
       expect(dimensions.width).toBe(100);
-      expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+      expect(transformedExt.mime).toMatch(/image\/webp/i);
       expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(0);
     },
@@ -288,7 +288,7 @@ describe("loader generator option", () => {
 
       expect(dimensions.height).toBe(1);
       expect(dimensions.width).toBe(1);
-      expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+      expect(transformedExt.mime).toMatch(/image\/webp/i);
       expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(0);
     },
@@ -334,7 +334,7 @@ describe("loader generator option", () => {
 
     expect(dimensions.height).toBe(50);
     expect(dimensions.width).toBe(100);
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/webp/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
@@ -379,7 +379,7 @@ describe("loader generator option", () => {
 
     expect(dimensions.height).toBe(1);
     expect(dimensions.width).toBe(1);
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/webp/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
@@ -411,7 +411,7 @@ describe("loader generator option", () => {
 
     const transformedExt = await fileType.fromFile(transformedAsset);
 
-    expect(/image\/jpeg/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/jpeg/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
@@ -457,7 +457,7 @@ describe("loader generator option", () => {
 
     expect(dimensions.height).toBe(50);
     expect(dimensions.width).toBe(100);
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/webp/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
@@ -489,7 +489,7 @@ describe("loader generator option", () => {
 
     const transformedExt = await fileType.fromFile(transformedAsset);
 
-    expect(/image\/jpeg/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/jpeg/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
@@ -535,7 +535,7 @@ describe("loader generator option", () => {
 
     expect(dimensions.height).toBe(50);
     expect(dimensions.width).toBe(100);
-    expect(/image\/webp/i.test(transformedExt.mime)).toBe(true);
+    expect(transformedExt.mime).toMatch(/image\/webp/i);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -418,7 +418,7 @@ describe("loader", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
   });
 
   ifit(needSquooshTest)(
@@ -455,7 +455,7 @@ describe("loader", () => {
       );
       const ext = await fileType.fromFile(file);
 
-      expect(/image\/webp/i.test(ext.mime)).toBe(true);
+      expect(ext.mime).toMatch(/image\/webp/i);
     },
   );
 
@@ -494,7 +494,7 @@ describe("loader", () => {
       );
       const ext = await fileType.fromFile(file);
 
-      expect(/image\/webp/i.test(ext.mime)).toBe(true);
+      expect(ext.mime).toMatch(/image\/webp/i);
     },
   );
 
@@ -531,7 +531,7 @@ describe("loader", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/webp/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/webp/i);
   });
 
   it("should throw an error on empty minimizer", async () => {

--- a/test/plugin-minimizer-option.test.js
+++ b/test/plugin-minimizer-option.test.js
@@ -514,7 +514,7 @@ describe("plugin minify option", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/png/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/png/i);
     expect(transformedAssets).toHaveLength(1);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
@@ -546,7 +546,7 @@ describe("plugin minify option", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/png/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/png/i);
     expect(transformedAssets).toHaveLength(1);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
@@ -578,7 +578,7 @@ describe("plugin minify option", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/png/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/png/i);
     expect(transformedAssets).toHaveLength(1);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
@@ -610,7 +610,7 @@ describe("plugin minify option", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/png/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/png/i);
     expect(transformedAssets).toHaveLength(1);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);
@@ -642,7 +642,7 @@ describe("plugin minify option", () => {
     );
     const ext = await fileType.fromFile(file);
 
-    expect(/image\/png/i.test(ext.mime)).toBe(true);
+    expect(ext.mime).toMatch(/image\/png/i);
     expect(transformedAssets).toHaveLength(1);
     expect(warnings).toHaveLength(0);
     expect(errors).toHaveLength(0);

--- a/test/resize-query.test.js
+++ b/test/resize-query.test.js
@@ -85,7 +85,7 @@ describe("resize query (sharp)", () => {
 
       expect(dimensions.width).toBe(width);
       expect(dimensions.height).toBe(height);
-      expect(mimeRegExp.test(transformedExt.mime)).toBe(true);
+      expect(transformedExt.mime).toMatch(mimeRegExp);
       expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(0);
     }
@@ -159,7 +159,7 @@ describe("resize query (sharp)", () => {
 
       expect(dimensions.width).toBe(width);
       expect(dimensions.height).toBe(height);
-      expect(mimeRegExp.test(transformedExt.mime)).toBe(true);
+      expect(transformedExt.mime).toMatch(mimeRegExp);
       expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(0);
     }
@@ -243,7 +243,7 @@ describe("resize query (sharp)", () => {
 
       expect(dimensions.width).toBe(width);
       expect(dimensions.height).toBe(height);
-      expect(mimeRegExp.test(transformedExt.mime)).toBe(true);
+      expect(transformedExt.mime).toMatch(mimeRegExp);
       expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(0);
     }
@@ -317,7 +317,7 @@ describe("resize query (sharp)", () => {
 
       expect(dimensions.width).toBe(width);
       expect(dimensions.height).toBe(height);
-      expect(mimeRegExp.test(transformedExt.mime)).toBe(true);
+      expect(transformedExt.mime).toMatch(mimeRegExp);
       expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(0);
     }
@@ -403,7 +403,7 @@ describe("resize query (squoosh)", () => {
 
         expect(dimensions.width).toBe(width);
         expect(dimensions.height).toBe(height);
-        expect(mimeRegExp.test(transformedExt.mime)).toBe(true);
+        expect(transformedExt.mime).toMatch(mimeRegExp);
         expect(warnings).toHaveLength(0);
         expect(errors).toHaveLength(0);
       }
@@ -480,7 +480,7 @@ describe("resize query (squoosh)", () => {
 
         expect(dimensions.width).toBe(width);
         expect(dimensions.height).toBe(height);
-        expect(mimeRegExp.test(transformedExt.mime)).toBe(true);
+        expect(transformedExt.mime).toMatch(mimeRegExp);
         expect(warnings).toHaveLength(0);
         expect(errors).toHaveLength(0);
       }

--- a/types/cache.d.ts
+++ b/types/cache.d.ts
@@ -1,0 +1,21 @@
+/** @param {BinaryLike} content */
+export function hashContent(content: BinaryLike): string;
+/**
+ * @param {Buffer} content
+ * @param {(resultWriteable: Writable) => Promise<void>} processContent
+ * @param {string} [cacheDir] If provided, will attempt to read the corresponding cached file instead of calling
+ * processContent.
+ * @returns {Promise<Buffer | undefined>}
+ */
+export function processAndMaybeCacheContent(
+  content: Buffer,
+  processContent: (resultWriteable: Writable) => Promise<void>,
+  cacheDir?: string | undefined,
+): Promise<Buffer | undefined>;
+/**
+ * <T>
+ */
+export type LoaderContext<T> = import("webpack").LoaderContext<T>;
+export type Writable = import("stream").Writable;
+export type BinaryLike = import("crypto").BinaryLike;
+export type Buffer = import("buffer").Buffer;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -225,4 +225,8 @@ type PluginOptions<T, G> = {
    * If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)
    */
   cacheDir?: string | undefined;
+  /**
+   * If true, skips using Webpack's cache.
+   */
+  bypassWebpackCache?: boolean | undefined;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -221,4 +221,8 @@ type PluginOptions<T, G> = {
    * Allows to remove original assets. Useful for converting to a `webp` and remove original assets.
    */
   deleteOriginalAssets?: boolean | undefined;
+  /**
+   * If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)
+   */
+  cacheDir?: string | undefined;
 };

--- a/types/loader.d.ts
+++ b/types/loader.d.ts
@@ -45,4 +45,8 @@ type LoaderOptions<T> = {
     | import("./index").Minimizer<T>[]
     | undefined;
   generator?: import("./index").Generator<T>[] | undefined;
+  /**
+   * If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)
+   */
+  cacheDir?: string | undefined;
 };

--- a/types/loader.d.ts
+++ b/types/loader.d.ts
@@ -49,4 +49,8 @@ type LoaderOptions<T> = {
    * If provided, ensures all image transformations are done only once and cached within this folder. (Sharp only)
    */
   cacheDir?: string | undefined;
+  /**
+   * If true, skips using Webpack's cache.
+   */
+  bypassWebpackCache?: boolean | undefined;
 };

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -41,6 +41,7 @@ export type SharpOptions = {
   rotate?: number | "auto" | undefined;
   sizeSuffix?: SizeSuffix | undefined;
   encodeOptions?: SharpEncodeOptions | undefined;
+  cacheDir?: string | undefined;
 };
 export type SizeSuffix = (width: number, height: number) => string;
 /**


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Without this feature, all users of this plugin are strictly dependent on webpack's caching behaviors, which are actually typically very duplicative especially for an operation like image optimization and conversions like this plugin affords. For instance, with Next.js or Nuxt.js you can use webpack's `cache.cacheDirectory` with `cache.type === 'filesystem'`, and it will create multiple separate webpack caches, leading to at least two independent caches (and therefore redundant transformations) of all the images this plugin outputs. Worse yet, different ways of this plugin operating (a minimizer vs a generator) that perform actually _the same underlying transformation_ will -- especially with the way the plugin currently uses Webpack's caching based on a serialization of the whole minimizer or generator -- cause the transformation to occur and then be cached many more times than necessary.

This PR therefore introduces an option `cacheDir`. It can be configured for the whole plugin, or a particular minimizer/generator, or even just a specific sharp transformation/preset. It operates at a relatively low level to cache the specific Sharp transformations that are needed directly to the filesystem where configured. Thanks to this, also included is a new option `bypassWebpackCache` to not unnecessarily rely on the Webpack cache explicitly as a part of this plugin.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None that I'm aware of; all tests still pass. And some of the tests have been modified to make use of the `cacheDir` and `bypassWebpackCache` options; but additional tests to specifically confirm the new behaviors are not included in this.

### Additional Info

**Note:** This is only integrated into the underlying Sharp transformer.

**Reference:** You can compare this to the old [imagemin-webpack-plugin's `cacheFolder` behavior](https://github.com/Klathmon/imagemin-webpack-plugin?tab=readme-ov-file#optionscachefolder). But please note that this behavior is much more sophisticated in two ways:
* it goes to considerable lengths to ensure thread-safety in even the context of multiple webpack processes running on the same volume referencing the same `cacheDir` (i.e. for Next.js or Nuxt.js w/ server and browser webpack processes running concurrently).
* it _does_ (unlike the `imagemin-webpack-plugin's `cacheFolder`) ensure that the cache is unique to both the transformation being done and the original image being transformed. The cache within the `cacheDir` is organized as follows: `{cacheDir}/{hash of the transformation options}/{hash of the original image}`

**This PR was branched off of https://github.com/webpack-contrib/image-minimizer-webpack-plugin/pull/464 and therefore includes all those changes as well.**