### PR TITLE
fix(src/loader.js): fix matchResource check

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -269,7 +269,7 @@ async function loader(content) {
     changeResource(this, output, query);
 
     // Change name of assets modules after generator
-    if (this._module && !this._module.matchResource) {
+    if (this._module && !("matchResource" in this._module)) {
       this._module.matchResource = `${output.filename}${query}`;
     }
   }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
When used with rspask >= 1.26, I get an error:
```
/node_modules/image-minimizer-webpack-plugin/dist/loader.js:200
            this._module.matchResource = `${output.filename}${query}`;
                                       ^

TypeError: Cannot set property matchResource of #<_Module> which has only a getter
    at Object.loader (project/node_modules/image-minimizer-webpack-plugin/dist/loader.js:200:40)

Node.js v22.11.0
```
https://github.com/web-infra-dev/rspack/commit/0d814424ddd5b67d75fcd46df9f1bf9edc1a5fa0
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
