### PR TITLE
fix: concurrency default value to avoid overload CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -2005,7 +2005,7 @@ Type:
 type concurrency = number;
 ```
 
-Default: `Math.max(1, os.cpus().length - 1)`
+Default: `Math.max(1, os.availableParallelism() - 1)`
 
 Maximum number of concurrency optimization processes in one time.
 

--- a/src/index.js
+++ b/src/index.js
@@ -315,10 +315,21 @@ class ImageMinimizerPlugin {
 
     // In some cases cpus() returns undefined
     // https://github.com/nodejs/node/issues/19022
-    // TODO fix me
     const limit = Math.max(
       1,
-      this.options.concurrency ?? os.cpus()?.length ?? 1,
+      this.options.concurrency ||
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+        (typeof os.availableParallelism === "function"
+          ? {
+              // eslint-disable-next-line n/no-unsupported-features/node-builtins
+              length: os.availableParallelism(),
+            }
+          : os.cpus() || {
+              // In some cases cpus() returns undefined
+              // https://github.com/nodejs/node/issues/19022
+              length: 1,
+            }
+        ).length - 1,
     );
     const { RawSource } = compiler.webpack.sources;
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Use `os.availableParallelism` and keep one process for webpack itself

### Breaking Changes

No

### Additional Info

No